### PR TITLE
Velocity, acceleration checking + self-collision checking node

### DIFF
--- a/nextagea_gazebo/config/nextagea_gazebo_control.yaml
+++ b/nextagea_gazebo/config/nextagea_gazebo_control.yaml
@@ -155,7 +155,79 @@ rarm_controller:
   action_monitor_rate: 100            # Override default
   stop_trajectory_duration: 0        # Override default
 
+# Trajectory Controllers ---------------------------------------
+botharm_controller:
+  type: effort_controllers/JointTrajectoryController
+  joints:
+    - LARM_JOINT0
+    - LARM_JOINT1
+    - LARM_JOINT2
+    - LARM_JOINT3
+    - LARM_JOINT4
+    - LARM_JOINT5
+    - RARM_JOINT0
+    - RARM_JOINT1
+    - RARM_JOINT2
+    - RARM_JOINT3
+    - RARM_JOINT4
+    - RARM_JOINT5
+  constraints:
+    goal_time: 0.5                   # Override default
+    stopped_velocity_tolerance: 0.02 # Override default
+    LARM_JOINT0:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    LARM_JOINT1:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    LARM_JOINT2:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    LARM_JOINT3:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    LARM_JOINT4:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    LARM_JOINT5:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    RARM_JOINT0:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    RARM_JOINT1:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    RARM_JOINT2:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    RARM_JOINT3:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    RARM_JOINT4:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
+    RARM_JOINT5:
+      trajectory: 0.05               # Not enforced if unspecified
+      goal: 0.02                     # Not enforced if unspecified
 
+  gains: # Required because we're controlling an effort interface
+    LARM_JOINT0: {p: 100, i: 0, d: 1}
+    LARM_JOINT1: {p: 200, i: 0, d: 1}
+    LARM_JOINT2: {p: 500, i: 0, d: 10}
+    LARM_JOINT3: {p: 100, i: 0, d: 10}
+    LARM_JOINT4: {p: 400, i: 0, d: 10}
+    LARM_JOINT5: {p: 100, i: 0, d: 1}
+    RARM_JOINT0: {p: 100, i: 0, d: 1}
+    RARM_JOINT1: {p: 200, i: 0, d: 1}
+    RARM_JOINT2: {p: 500, i: 0, d: 10}
+    RARM_JOINT3: {p: 100, i: 0, d: 10}
+    RARM_JOINT4: {p: 400, i: 0, d: 10}
+    RARM_JOINT5: {p: 100, i: 0, d: 1}
+  state_publish_rate:  100            # Override default
+  action_monitor_rate: 100            # Override default
+  stop_trajectory_duration: 0        # Override default
+  
 # Trajectory Controllers ---------------------------------------
 head_controller:
   type: effort_controllers/JointTrajectoryController

--- a/nextagea_gazebo/config/nextagea_gazebo_control.yaml
+++ b/nextagea_gazebo/config/nextagea_gazebo_control.yaml
@@ -156,7 +156,7 @@ rarm_controller:
   stop_trajectory_duration: 0        # Override default
 
 # Trajectory Controllers ---------------------------------------
-botharm_controller:
+botharms_controller:
   type: effort_controllers/JointTrajectoryController
   joints:
     - LARM_JOINT0

--- a/nextagea_gazebo/launch/nextagea_gazebo_control.launch
+++ b/nextagea_gazebo/launch/nextagea_gazebo_control.launch
@@ -16,5 +16,5 @@
         output="screen" args="--stopped larm_controller
                                         rarm_controller"/>
 
-  <!-- <node name="go_home" pkg="nextagea_gazebo"  type="go_home" /> -->
+  <node name="go_home" pkg="nextagea_gazebo"  type="go_home" />
 </launch>

--- a/nextagea_gazebo/launch/nextagea_gazebo_control.launch
+++ b/nextagea_gazebo/launch/nextagea_gazebo_control.launch
@@ -10,5 +10,5 @@
                               rarm_controller
                               head_controller
                               torso_controller"/>
-  <!-- <node name="go_initial" pkg="nextagea_gazebo"  type="go_initial.py" /> -->
+  <node name="go_initial" pkg="motions"  type="go_initial" /> -->
 </launch>

--- a/nextagea_gazebo/launch/nextagea_gazebo_control.launch
+++ b/nextagea_gazebo/launch/nextagea_gazebo_control.launch
@@ -11,6 +11,7 @@
                               torso_controller"/>
 
   <!-- load the stopped controllers -->
+  <!-- please run the controller switch script in nextagea_gazebo/scripts to switch to rarm/larm from both arm controller-->
   <node name="stopped_controller_spawner" pkg="controller_manager"
         type="spawner" respawn="false"
         output="screen" args="--stopped larm_controller

--- a/nextagea_gazebo/launch/nextagea_gazebo_control.launch
+++ b/nextagea_gazebo/launch/nextagea_gazebo_control.launch
@@ -10,5 +10,5 @@
                               rarm_controller
                               head_controller
                               torso_controller"/>
-  <node name="go_initial" pkg="motions"  type="go_initial" /> -->
+  <node name="go_home" pkg="nextagea_gazebo"  type="go_home" />
 </launch>

--- a/nextagea_gazebo/launch/nextagea_gazebo_control.launch
+++ b/nextagea_gazebo/launch/nextagea_gazebo_control.launch
@@ -6,7 +6,7 @@
   <node name="controller_spawner" pkg="controller_manager"
         type="spawner" respawn="false"
         output="screen" args="joint_state_controller
-                              botharm_controller
+                              botharms_controller
                               head_controller
                               torso_controller"/>
 

--- a/nextagea_gazebo/launch/nextagea_gazebo_control.launch
+++ b/nextagea_gazebo/launch/nextagea_gazebo_control.launch
@@ -6,9 +6,15 @@
   <node name="controller_spawner" pkg="controller_manager"
         type="spawner" respawn="false"
         output="screen" args="joint_state_controller
-                              larm_controller
-                              rarm_controller
+                              botharm_controller
                               head_controller
                               torso_controller"/>
-  <node name="go_home" pkg="nextagea_gazebo"  type="go_home" />
+
+  <!-- load the stopped controllers -->
+  <node name="stopped_controller_spawner" pkg="controller_manager"
+        type="spawner" respawn="false"
+        output="screen" args="--stopped larm_controller
+                                        rarm_controller"/>
+
+  <!-- <node name="go_home" pkg="nextagea_gazebo"  type="go_home" /> -->
 </launch>

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -44,9 +44,9 @@
   <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="">
     <param name="controller_type" value="$(arg controller_type)"/>
     <param name="collision_mode" value="$(arg collision_mode)"/>
-    <remap from="~traj_input" to="/collision_botharms_controller/command" />
-    <remap from="~traj_output" to="/botharms_controller/command" />
-    <remap from="~arm_input" to="/botharms_controller/state" />
+    <remap from="~traj_input" to="/collision_$(arg controller_type)_controller/command" />
+    <remap from="~traj_output" to="/$(arg controller_type)_controller/command" />
+    <remap from="~arm_input" to="/$(arg controller_type)_controller/state" />
   </node>
 
   <!-- start gazebo server-->

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -43,11 +43,15 @@
   <arg name="collision_mode" value="error"/>
   <!-- use check_param to select what you want to check: self-collision + velocities + acceleration (cva), just self-collision (c), just velocity (v), just acceleration (a)-->
   <arg name="check_param" value="cva"/>
+  <!-- use all_acceleration_limits to pass in acceleration limits for each of the 15 Nextage joints: CHEST *1, HEAD *2, LARM *6, RARM *6-->
+  <!-- NOTE: Velocity and joint limits are defined in the URDF-->
+  <arg name="all_acceleration_limits" value="[0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]"/>
 
   <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="">
     <param name="controller_type" value="$(arg controller_type)"/>
     <param name="collision_mode" value="$(arg collision_mode)"/>
     <param name="check_param" value="$(arg check_param)"/>
+    <param name="all_acceleration_limits" value="$(arg all_acceleration_limits)"/>
     <remap from="~traj_input" to="/collision_$(arg controller_type)_controller/command" />
     <remap from="~traj_output" to="/$(arg controller_type)_controller/command" />
     <remap from="~arm_input" to="/$(arg controller_type)_controller/state" />

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -39,7 +39,7 @@
   <!-- start self-collision checker -->
   <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen">
     <remap from="~traj_input" to="/rarm_controller/command" />
-    <remap from="~traj_output" to="/rarm_controller/command" />
+    <remap from="~traj_output" to="/self_collision_check/output" />
     <remap from="~larm_input" to="/larm_controller/state" />
     <remap from="~rarm_input" to="/rarm_controller/state" />
   </node>

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -41,7 +41,7 @@
   <arg name="controller_type" value="botharms"/>
   <!-- use collision_mode to select error/warn behaviour-->
   <arg name="collision_mode" value="error"/>
-  <!-- use check_param to select what you want to check: self-collision + velocities + acceleration (cva), just self-collision (c), just velocity (v), just acceleration (a)-->
+  <!-- use check_param to select what you want to check: self-collision + velocities + acceleration (cva), just self-collision (c), just velocity (v), just acceleration (a) or velocity and acceleration (va) -->
   <arg name="check_param" value="cva"/>
   <!-- use all_acceleration_limits to pass in acceleration limits for each of the 15 Nextage joints: CHEST *1, HEAD *2, LARM *6, RARM *6-->
   <!-- NOTE: Velocity and joint limits are defined in the URDF-->

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -54,7 +54,7 @@
     <param name="all_acceleration_limits" value="$(arg all_acceleration_limits)"/>
     <remap from="~traj_input" to="/collision_$(arg controller_type)_controller/command" />
     <remap from="~traj_output" to="/$(arg controller_type)_controller/command" />
-    <remap from="~arm_input" to="/$(arg controller_type)_controller/state" />
+    <remap from="~joint_state" to="/joint_states" />
   </node>
 
   <!-- start gazebo server-->

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -41,10 +41,12 @@
   <arg name="controller_type" value="botharms"/>
   <!-- use collision_mode to select error/warn behaviour-->
   <arg name="collision_mode" value="warn"/>
-  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="--mode $(arg collision_mode) --type $(arg controller_type) --remaps">
-    <remap from="~traj_input" to="/collision_$(arg controller_type)_controller/command" />
-    <remap from="~traj_output" to="/$(arg controller_type)_controller/command" />
-    <remap from="~arm_input" to="/$(arg controller_type)_controller/state" />
+  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="">
+    <param name="controller_type" value="$(arg controller_type)"/>
+    <param name="collision_mode" value="$(arg collision_mode)"/>
+    <remap from="~traj_input" to="/collision_botharms_controller/command" />
+    <remap from="~traj_output" to="/botharms_controller/command" />
+    <remap from="~arm_input" to="/botharms_controller/state" />
   </node>
 
   <!-- start gazebo server-->

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -40,7 +40,7 @@
   <!-- use controller_type to identify whether using botharms/rarm/larm controller-->
   <arg name="controller_type" value="botharms"/>
   <!-- use collision_mode to select error/warn behaviour-->
-  <arg name="collision_mode" value="warn"/>
+  <arg name="collision_mode" value="error"/>
   <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="">
     <param name="controller_type" value="$(arg controller_type)"/>
     <param name="collision_mode" value="$(arg collision_mode)"/>

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -41,9 +41,13 @@
   <arg name="controller_type" value="botharms"/>
   <!-- use collision_mode to select error/warn behaviour-->
   <arg name="collision_mode" value="error"/>
+  <!-- use check_param to select what you want to check: self-collision + velocities + acceleration (cva), just self-collision (c), just velocity (v), just acceleration (a)-->
+  <arg name="check_param" value="cva"/>
+
   <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="">
     <param name="controller_type" value="$(arg controller_type)"/>
     <param name="collision_mode" value="$(arg collision_mode)"/>
+    <param name="check_param" value="$(arg check_param)"/>
     <remap from="~traj_input" to="/collision_$(arg controller_type)_controller/command" />
     <remap from="~traj_output" to="/$(arg controller_type)_controller/command" />
     <remap from="~arm_input" to="/$(arg controller_type)_controller/state" />

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -36,6 +36,14 @@
   <arg unless="$(arg debug)" name="script_type" value="gzserver"/>
   <arg     if="$(arg debug)" name="script_type" value="debug"/>
 
+  <!-- start self-collision checker -->
+  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen">
+    <remap from="~traj_input" to="/rarm_controller/command" />
+    <remap from="~traj_output" to="/rarm_controller/command" />
+    <remap from="~larm_input" to="/larm_controller/state" />
+    <remap from="~rarm_input" to="/rarm_controller/state" />
+  </node>
+
   <!-- start gazebo server-->
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="false" output="screen"
 	args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" >

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -38,7 +38,7 @@
 
   <!-- start self-collision checker -->
   <!-- use controller_type to identify whether using botharm/rarm/larm controller. Change remaps match-->
-  <arg name="controller_type" value="botharm"/>
+  <arg name="controller_type" value="botharms"/>
   <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="-warn $(arg controller_type)">
     <remap from="~traj_input" to="/collision_botharm_controller/command" />
     <remap from="~traj_output" to="/botharm_controller/command" />

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -37,11 +37,12 @@
   <arg     if="$(arg debug)" name="script_type" value="debug"/>
 
   <!-- start self-collision checker -->
-  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="-warn">
-    <remap from="~traj_input" to="/collision_rarm_controller/command" />
-    <remap from="~traj_output" to="/rarm_controller/command" />
-    <remap from="~larm_input" to="/larm_controller/state" />
-    <remap from="~rarm_input" to="/rarm_controller/state" />
+  <!-- use controller_type to identify whether using botharm/rarm/larm controller. Change remaps match-->
+  <arg name="controller_type" value="botharm"/>
+  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="-warn $(arg controller_type)">
+    <remap from="~traj_input" to="/collision_botharm_controller/command" />
+    <remap from="~traj_output" to="/botharm_controller/command" />
+    <remap from="~arm_input" to="/botharm_controller/state" />
   </node>
 
   <!-- start gazebo server-->

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -37,9 +37,9 @@
   <arg     if="$(arg debug)" name="script_type" value="debug"/>
 
   <!-- start self-collision checker -->
-  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen">
-    <remap from="~traj_input" to="/rarm_controller/command" />
-    <remap from="~traj_output" to="/self_collision_check/output" />
+  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="-warn">
+    <remap from="~traj_input" to="/collision_rarm_controller/command" />
+    <remap from="~traj_output" to="/rarm_controller/command" />
     <remap from="~larm_input" to="/larm_controller/state" />
     <remap from="~rarm_input" to="/rarm_controller/state" />
   </node>

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -37,12 +37,12 @@
   <arg     if="$(arg debug)" name="script_type" value="debug"/>
 
   <!-- start self-collision checker -->
-  <!-- use controller_type to identify whether using botharm/rarm/larm controller. Change remaps match-->
+  <!-- use controller_type to identify whether using botharms/rarm/larm controller. Changes remaps to match-->
   <arg name="controller_type" value="botharms"/>
   <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="-warn $(arg controller_type)">
-    <remap from="~traj_input" to="/collision_botharm_controller/command" />
-    <remap from="~traj_output" to="/botharm_controller/command" />
-    <remap from="~arm_input" to="/botharm_controller/state" />
+    <remap from="~traj_input" to="/collision_$(arg controller_type)_controller/command" />
+    <remap from="~traj_output" to="/$(arg controller_type)_controller/command" />
+    <remap from="~arm_input" to="/$(arg controller_type)_controller/state" />
   </node>
 
   <!-- start gazebo server-->

--- a/nextagea_gazebo/launch/nextagea_world.launch
+++ b/nextagea_gazebo/launch/nextagea_world.launch
@@ -37,9 +37,11 @@
   <arg     if="$(arg debug)" name="script_type" value="debug"/>
 
   <!-- start self-collision checker -->
-  <!-- use controller_type to identify whether using botharms/rarm/larm controller. Changes remaps to match-->
+  <!-- use controller_type to identify whether using botharms/rarm/larm controller-->
   <arg name="controller_type" value="botharms"/>
-  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="-warn $(arg controller_type)">
+  <!-- use collision_mode to select error/warn behaviour-->
+  <arg name="collision_mode" value="warn"/>
+  <node name="self_collision_check" pkg="nextagea_gazebo" type="self_collision_check" output="screen" args="--mode $(arg collision_mode) --type $(arg controller_type) --remaps">
     <remap from="~traj_input" to="/collision_$(arg controller_type)_controller/command" />
     <remap from="~traj_output" to="/$(arg controller_type)_controller/command" />
     <remap from="~arm_input" to="/$(arg controller_type)_controller/state" />

--- a/nextagea_gazebo/scripts/go_home
+++ b/nextagea_gazebo/scripts/go_home
@@ -10,31 +10,25 @@ import sys
 class Arms:
 
     def __init__(self, joint):
-        self.rpub = rospy.Publisher("/rarm_controller/command", JointTrajectory, queue_size=1)
-        self.rnames = [u'RARM_JOINT0', u'RARM_JOINT1', u'RARM_JOINT2', u'RARM_JOINT3', u'RARM_JOINT4', u'RARM_JOINT5']
-        self.lpub = rospy.Publisher("/larm_controller/command", JointTrajectory, queue_size=1)
-        self.lnames = [u'LARM_JOINT0', u'LARM_JOINT1', u'LARM_JOINT2', u'LARM_JOINT3', u'LARM_JOINT4', u'LARM_JOINT5']
+        self.pub = rospy.Publisher("/botharm_controller/command", JointTrajectory, queue_size=1)
+        self.names = [u'LARM_JOINT0', u'LARM_JOINT1', u'LARM_JOINT2', u'LARM_JOINT3', u'LARM_JOINT4', u'LARM_JOINT5', u'RARM_JOINT0', u'RARM_JOINT1', u'RARM_JOINT2', u'RARM_JOINT3', u'RARM_JOINT4', u'RARM_JOINT5']
 
     def go_init(self):
         print("Nextage going to init pos")
-        initpos = np.zeros(6)
+        initpos = np.zeros(12)
         timing = 3.0
 
         trajectory_message = JointTrajectory()
         point = JointTrajectoryPoint()
-        point.velocities = np.zeros(6).tolist()
+        point.velocities = np.zeros(12).tolist()
         point.positions = initpos.tolist()
         point.time_from_start = rospy.Duration(timing)
         trajectory_message.points.append(point)
 
-        trajectory_message.joint_names = [x.encode('ascii') for x in self.rnames]
+        trajectory_message.joint_names = [x.encode('ascii') for x in self.names]
         trajectory_message.header.stamp = rospy.Time.now()
         time.sleep(5)
-        self.rpub.publish(trajectory_message)
-
-        trajectory_message.joint_names = [x.encode('ascii') for x in self.lnames]
-        trajectory_message.header.stamp = rospy.Time.now()
-        self.lpub.publish(trajectory_message)
+        self.pub.publish(trajectory_message)
 
 def main(args):
     rospy.init_node("go_init")

--- a/nextagea_gazebo/scripts/go_home
+++ b/nextagea_gazebo/scripts/go_home
@@ -10,7 +10,7 @@ import sys
 class Arms:
 
     def __init__(self, joint):
-        self.pub = rospy.Publisher("/botharm_controller/command", JointTrajectory, queue_size=1)
+        self.pub = rospy.Publisher("/botharms_controller/command", JointTrajectory, queue_size=1)
         self.names = [u'LARM_JOINT0', u'LARM_JOINT1', u'LARM_JOINT2', u'LARM_JOINT3', u'LARM_JOINT4', u'LARM_JOINT5', u'RARM_JOINT0', u'RARM_JOINT1', u'RARM_JOINT2', u'RARM_JOINT3', u'RARM_JOINT4', u'RARM_JOINT5']
 
     def go_init(self):

--- a/nextagea_gazebo/scripts/go_home
+++ b/nextagea_gazebo/scripts/go_home
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Nextage Go Home Script
+
+from trajectory_msgs.msg import JointTrajectoryPoint, JointTrajectory
+import numpy as np
+import rospy
+import time
+import sys
+
+class Arms:
+
+    def __init__(self, joint):
+        self.rpub = rospy.Publisher("/rarm_controller/command", JointTrajectory, queue_size=1)
+        self.rnames = [u'RARM_JOINT0', u'RARM_JOINT1', u'RARM_JOINT2', u'RARM_JOINT3', u'RARM_JOINT4', u'RARM_JOINT5']
+        self.lpub = rospy.Publisher("/larm_controller/command", JointTrajectory, queue_size=1)
+        self.lnames = [u'LARM_JOINT0', u'LARM_JOINT1', u'LARM_JOINT2', u'LARM_JOINT3', u'LARM_JOINT4', u'LARM_JOINT5']
+
+    def go_init(self):
+        print("Nextage going to init pos")
+        initpos = np.zeros(6)
+        timing = 3.0
+
+        trajectory_message = JointTrajectory()
+        point = JointTrajectoryPoint()
+        point.velocities = np.zeros(6).tolist()
+        point.positions = initpos.tolist()
+        point.time_from_start = rospy.Duration(timing)
+        trajectory_message.points.append(point)
+
+        trajectory_message.joint_names = [x.encode('ascii') for x in self.rnames]
+        trajectory_message.header.stamp = rospy.Time.now()
+        time.sleep(5)
+        self.rpub.publish(trajectory_message)
+
+        trajectory_message.joint_names = [x.encode('ascii') for x in self.lnames]
+        trajectory_message.header.stamp = rospy.Time.now()
+        self.lpub.publish(trajectory_message)
+
+def main(args):
+    rospy.init_node("go_init")
+    robot = Arms(args)
+    robot.go_init()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/nextagea_gazebo/scripts/go_home
+++ b/nextagea_gazebo/scripts/go_home
@@ -30,10 +30,7 @@ class Arms:
         time.sleep(5)
         self.pub.publish(trajectory_message)
 
-def main(args):
-    rospy.init_node("go_init")
-    robot = Arms(args)
-    robot.go_init()
-
 if __name__ == '__main__':
-    main(sys.argv)
+    rospy.init_node("go_init")
+    robot = Arms(sys.argv)
+    robot.go_init()

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Self-collision checker for Nextage platform
 
 import pyexotica as exo
 from pyexotica.publish_trajectory import *
@@ -19,45 +20,47 @@ class colours:
     ENDC = '\033[0m'
 
 class SelfCollisionCheck:
-    '''Self-collision checker for the Nextage platform. Node sits in front of trajectory controller and filters
+    '''Self-collision checker for the Nextage platform. Node sits in front of trajectory controllers and filters
     out potentially harmful trajectories that may cause self-collisions'''
 
-    def __init__(self):
+    def __init__(self, MODE, CONTROLLER_TYPE):
         # Initial setup and sub/pub to nodes
-        self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.callback, queue_size=1)
+        self.controller_type = CONTROLLER_TYPE
+        self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
+        self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
 
-        # TODO: Perhaps this would be better setup as a ROS service that keeps a track of the current robot state
-        # at a set rate (say 2x a second), rather than querying in this program. Minor change
-        self.left_arm = rospy.Subscriber(rospy.resolve_name("~larm_input"), JointTrajectoryControllerState, self.larm_callback, queue_size=1)
-        self.right_arm = rospy.Subscriber(rospy.resolve_name("~rarm_input"), JointTrajectoryControllerState, self.rarm_callback, queue_size=1)
-
-        # Get EXOTica problem
-        self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/collision_setup.xml')
-
+        # Get EXOTica problem, different controllers correspond to different problem setups with different JointGroup
+        if self.controller_type == "botharm":
+            self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/botharms_collision_setup.xml')
+        elif self.controller_type == "rarm":
+            self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/rarm_collision_setup.xml')
+        elif self.controller_type == "larm":
+            self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/larm_collision_setup.xml')
+        else:
+            raise ValueError("Unrecognised trajectory input: %s" % self.controller_type)
+        
+        self.mode = MODE
         self.check_trajectory = False
         self.rate = rospy.Rate(10)
 
-    def callback(self, data):
-        # Process JointTrajectory to be EXOTica solution form
+    def input_callback(self, data):
         self.check_trajectory = True
         self.trajectory_message = data
     
-    def larm_callback(self, data):
-        self.larm_state = data
-
-    def rarm_callback(self, data):
-        self.rarm_state = data
+    def arm_callback(self, data):
+        # Get current joint states
+        self.arm_state = data
 
     def spin(self):
         while not rospy.is_shutdown():
             if self.check_trajectory:
                 # TODO: Wrap in try/except block
-                # TODO: Currently outputs a self-collision if it starts in self-collision and then moves out of it
+                # TODO: Currently outputs a self-collision if it starts in self-collision and then moves out of it, is this desired behaviour?
 
                 # Find robot's current state
-                # current_arms = list(self.larm_state.actual.positions) += list(self.rarm_state.actual.positions)
-                current_arms = list(self.rarm_state.actual.positions)
+                current_arms = list(self.arm_state.actual.positions)
+                print(current_arms)
 
                 # Strip JointTrajectory down to be in EXOTica solution form
                 list_traj = [current_arms]
@@ -71,12 +74,14 @@ class SelfCollisionCheck:
                     # Pass through trajectory
                     self.output_traj.publish(self.trajectory_message)
                 else:
-                    if MODE == '-warn':
+                    if self.mode == '-warn':
+                        # Print warning, but also pass through trajectory
                         print(colours.WARNING + "[WARN] Self-collision detected on following links:")
                         get_colliding_links(self.problem.get_scene())
                         print(colours.ENDC)
                         self.output_traj.publish(self.trajectory_message)
-                    elif MODE == '-error':
+                    elif self.mode == '-error':
+                        # Print error, don't pass through trajectory
                         print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
                         get_colliding_links(self.problem.get_scene())
                         print(colours.ENDC)                        
@@ -87,12 +92,12 @@ class SelfCollisionCheck:
 
 
 def main(args):
-    # Sets warning/error message behaviour
-    global MODE 
+    # Sets warning/error message behaviour & controller type
     MODE = args[1]
+    CONTROLLER_TYPE = args[2]
 
     rospy.init_node('self_collision_check')
-    col = SelfCollisionCheck()
+    col = SelfCollisionCheck(MODE, CONTROLLER_TYPE)
     try:
         col.spin()
     except KeyboardInterrupt:

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -87,8 +87,10 @@ class SelfCollisionCheck:
 
 
 def main(args):
+    # Sets warning/error message behaviour
     global MODE 
     MODE = args[1]
+
     rospy.init_node('self_collision_check')
     col = SelfCollisionCheck()
     try:

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -55,7 +55,6 @@ class SelfCollisionCheck:
         while not rospy.is_shutdown():
             try:
                 if self.check_trajectory:
-                    # TODO: Currently outputs a self-collision if it starts in self-collision and then moves out of it, is this desired behaviour?
 
                     # Find robot's current state
                     current_arms = list(self.arm_state.actual.positions)

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -160,9 +160,15 @@ class SelfCollisionCheck:
                         accel_check, accel_vals = (True, [])
 
                     # if checking only accelerations
-                    else:
+                    elif self.check == "a":
                         traj_check = True
                         vel_check, vel_vals = (True, [])
+                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
+
+                    # else if checking velocities and accelerations
+                    else:
+                        traj_check = True
+                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
                         accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
 
                     # Validates checks in following order: self-collision, velocity limits, acceleration limits - prints first failure
@@ -224,7 +230,7 @@ def main(args):
     # Get controller_type, mode and check parameters
     valid_mode = ["warn", "error"]
     valid_type = ["botharms", "rarm", "larm"]
-    valid_check = ["cva", "c", "v", "a"]
+    valid_check = ["cva", "c", "v", "a", "va"]
 
     MODE = rospy.get_param("/self_collision_check/collision_mode")
     CONTROLLER_TYPE = rospy.get_param("/self_collision_check/controller_type")

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -6,7 +6,6 @@ from pyexotica.publish_trajectory import *
 import signal
 import sys
 import rospy
-from time import sleep
 import numpy as np
 from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsampling, get_colliding_links
 from trajectory_msgs.msg import JointTrajectory
@@ -96,10 +95,28 @@ class SelfCollisionCheck:
 
 
 def main(args):
-    # Sets warning/error message behaviour & controller type
-    MODE = args[1]
-    # Check CONTROLLER_TYPE is one of the supported: botharms, rarm, larm
-    CONTROLLER_TYPE = args[2]
+    import argparse
+
+    valid_mode = ["warn", "error"]
+    valid_type = ["botharms", "rarm", "larm"]
+
+    parser = argparse.ArgumentParser(description="Nextage self-collision checker")
+    parser.add_argument("--mode", "-m", type=str, nargs="?", default="warn")
+    parser.add_argument("--type", "-t", type=str, nargs="?", default="botharms")
+    parser.add_argument("--remaps", type=str, nargs="?")
+    parser.add_argument('args', nargs=argparse.REMAINDER) # Needed to allow remap args
+    results = parser.parse_args()
+    if results.mode not in valid_mode:
+        print("Invalid collision mode! Use only the following: " + str(valid_mode))
+        parser.print_usage()
+        exit(1)
+    if results.type not in valid_type:
+        print("Invalid controller type! Use only the following: " + str(valid_type))
+        parser.print_usage()
+        exit(1)
+
+    MODE = results.mode
+    CONTROLLER_TYPE = results.type
 
     rospy.init_node('self_collision_check')
     col = SelfCollisionCheck(MODE, CONTROLLER_TYPE)

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -10,8 +10,7 @@ import numpy as np
 from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsampling, get_colliding_links
 from trajectory_msgs.msg import JointTrajectory
 from control_msgs.msg import JointTrajectoryControllerState
-from xml.dom.minidom import parse
-from rospkg import RosPack
+from json import loads
 
 class colours:
     WARNING = '\033[93m'
@@ -23,11 +22,12 @@ class SelfCollisionCheck:
     Node sits in front of trajectory controllers and filters out potentially harmful trajectories that may cause 
     self-collisions'''
 
-    def __init__(self, MODE, CONTROLLER_TYPE, CHECK):
+    def __init__(self, MODE, CONTROLLER_TYPE, CHECK, ALL_ACCELERATION_LIMITS):
 
         self.controller_type = CONTROLLER_TYPE
         self.mode = MODE
         self.check = CHECK
+        all_acceleration_limits = ALL_ACCELERATION_LIMITS
 
         # Initial setup and sub/pub to nodes
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
@@ -45,13 +45,8 @@ class SelfCollisionCheck:
         
         # Get velocity limits
         self.velocity_limits = self.scene.get_kinematic_tree().get_velocity_limits()
-        # Get acceleration limits from the URDF - not part of the URDF standard and so must be manually retrieved
-        rospack = RosPack()
-        urdf = parse(rospack.get_path("nextagea_description") + "/urdf/NextageAOpen.urdf")
-        joints = urdf.getElementsByTagName("joint")[-15:] # Nextage has 15 joints: 1 CHEST, 2 HEAD, 6 LARM, 6 RARM
-        all_acceleration_limits = [float(joint.getElementsByTagName("limit")[0].getAttribute("acceleration")) for joint in joints]
 
-        # Set names for joint group and select acceleration limits to match
+        # Set names for joint group and select acceleration limits to match - acceleration limits passed in from rosparams (see launch file: nextagea_world.launch)
         if rospy.resolve_name("~traj_input") == "/collision_botharms_controller/command":
             self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5', 'RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
             self.acceleration_limits = np.array(all_acceleration_limits[-12:])
@@ -234,6 +229,7 @@ def main(args):
     MODE = rospy.get_param("/self_collision_check/collision_mode")
     CONTROLLER_TYPE = rospy.get_param("/self_collision_check/controller_type")
     CHECK = rospy.get_param("/self_collision_check/check_param")
+    ALL_ACCELERATION_LIMITS = np.array(loads(rospy.get_param("/self_collision_check/all_acceleration_limits")))
     if MODE not in valid_mode:
         print("Detected self_collision_check mode: " + MODE)
         print("Invalid collision mode! Use only the following: " + str(valid_mode))
@@ -245,10 +241,14 @@ def main(args):
     if CHECK not in valid_check:
         print("Detected self_collision_check check parameter: " + CHECK)
         print("Invalid checking options! Use only the following: " + str(valid_check))
-        exit(1)  
+        exit(1)
+    if ALL_ACCELERATION_LIMITS.size != 15:
+        print("Incorrect acceleration limit size! Detected: " + str(ALL_ACCELERATION_LIMITS.size))
+        print("Acceleration limits must be size=15: CHEST *1, HEAD *2, LARM *6, RARM *6")
+        exit(1)
 
     rospy.init_node('self_collision_check')
-    col = SelfCollisionCheck(MODE, CONTROLLER_TYPE, CHECK)
+    col = SelfCollisionCheck(MODE, CONTROLLER_TYPE, CHECK, ALL_ACCELERATION_LIMITS)
     try:
         col.spin()
     except KeyboardInterrupt:

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -5,13 +5,11 @@ import pyexotica as exo
 from pyexotica.publish_trajectory import *
 import signal
 import sys
-import warnings
 import rospy
 from time import sleep
 import numpy as np
 from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsampling, get_colliding_links
-from trajectory_msgs.msg import JointTrajectoryPoint, JointTrajectory
-from sensor_msgs.msg import JointState
+from trajectory_msgs.msg import JointTrajectory
 from control_msgs.msg import JointTrajectoryControllerState
 
 class colours:
@@ -30,15 +28,14 @@ class SelfCollisionCheck:
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
         self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
 
-        # Get EXOTica problem, different controllers correspond to different problem setups with different JointGroup
-        if self.controller_type == "botharm":
-            self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/botharms_collision_setup.xml')
-        elif self.controller_type == "rarm":
-            self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/rarm_collision_setup.xml')
-        elif self.controller_type == "larm":
-            self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/larm_collision_setup.xml')
-        else:
-            raise ValueError("Unrecognised trajectory input: %s" % self.controller_type)
+        # Setup EXOTica scene with corresponding JointGroup
+        init = exo.Initializers.SceneInitializer()
+        init[1]['JointGroup'] = str(self.controller_type)
+        init[1]['URDF'] = '{nextagea_description}/urdf/NextageAOpen.urdf'
+        init[1]['SRDF'] = '{nextagea_moveit_config}/config/NextageAOpen.srdf'
+        init[1]['AlwaysUpdateCollisionScene'] = True
+        init[1]['CollisionScene'] = 'CollisionSceneFCLLatest'
+        self.scene = exo.Setup.create_scene(init)
         
         self.mode = MODE
         self.check_trajectory = False
@@ -76,13 +73,13 @@ class SelfCollisionCheck:
                         if self.mode == '-warn':
                             # Print warning, but also pass through trajectory
                             print(colours.WARNING + "[WARN] Self-collision detected on following links:")
-                            get_colliding_links(self.problem.get_scene())
+                            get_colliding_links(self.scene)
                             print(colours.ENDC)
                             self.output_traj.publish(self.trajectory_message)
                         elif self.mode == '-error':
                             # Print error, don't pass through trajectory
                             print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
-                            get_colliding_links(self.problem.get_scene())
+                            get_colliding_links(self.scene)
                             print(colours.ENDC)                        
                     
                     self.check_trajectory = False
@@ -99,6 +96,7 @@ class SelfCollisionCheck:
 def main(args):
     # Sets warning/error message behaviour & controller type
     MODE = args[1]
+    # Check CONTROLLER_TYPE is one of the supported: botharms, rarm, larm
     CONTROLLER_TYPE = args[2]
 
     rospy.init_node('self_collision_check')

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -106,7 +106,7 @@ def main(args):
     valid_type = ["botharms", "rarm", "larm"]
 
     MODE = rospy.get_param("/self_collision_check/collision_mode")
-    CONTROLLER_TYPE = rospy.get_param("self_collision_check/controller_type")
+    CONTROLLER_TYPE = rospy.get_param("/self_collision_check/controller_type")
     if MODE not in valid_mode:
         print("Detected self_collision_check mode: " + MODE)
         print("Invalid collision mode! Use only the following: " + str(valid_mode))

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -9,30 +9,25 @@ import rospy
 import numpy as np
 from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsampling, get_colliding_links
 from trajectory_msgs.msg import JointTrajectory
-from control_msgs.msg import JointTrajectoryControllerState
+from sensor_msgs.msg import JointState
 from json import loads
-
-class colours:
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
 
 class SelfCollisionCheck:
     '''Trajectory checker for the Nextage platform - checks self-collision, velocity and acceleration limits. 
     Node sits in front of trajectory controllers and filters out potentially harmful trajectories that may cause 
     self-collisions'''
 
-    def __init__(self, MODE, CONTROLLER_TYPE, CHECK, ALL_ACCELERATION_LIMITS):
+    def __init__(self, mode, controller_type, check, all_acceleration_limits):
 
-        self.controller_type = CONTROLLER_TYPE
-        self.mode = MODE
-        self.check = CHECK
-        all_acceleration_limits = ALL_ACCELERATION_LIMITS
+        self.controller_type = controller_type
+        self.mode = mode
+        self.check = check
+        all_acceleration_limits = all_acceleration_limits
 
         # Initial setup and sub/pub to nodes
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
-        self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
+        self.arm_info = rospy.Subscriber(rospy.resolve_name("~joint_state"), JointState, self.arm_callback, queue_size=1)
 
         # Setup EXOTica scene with corresponding JointGroup
         init = exo.Initializers.SceneInitializer()
@@ -65,16 +60,25 @@ class SelfCollisionCheck:
         if self.check_trajectory == False:
             self.check_trajectory = True
             self.trajectory_message = data
-    
+        # Else warn that the trajectory is being ignored
+        else:
+            rospy.logwarn("Trajectory currently being processed, new trajectory is being ignored!")
+
     def arm_callback(self, data):
-        # Get current joint states
-        self.arm_state = data
+        # Get current joint states for joint group
+        joint_states = data.position
+        if rospy.resolve_name("~traj_input") == "/collision_botharms_controller/command":
+            self.arm_pos = joint_states[-12:]
+        elif rospy.resolve_name("~traj_input") == "/collision_rarm_controller/command":
+            self.arm_pos = joint_states[-6:]
+        else:
+            self.arm_pos = joint_states[3:9]
     
-    def check_trajectory_velocities(self, arm_state, velocity_limits, trajectory_message):
+    def check_trajectory_velocities(self, arm_pos, velocity_limits, trajectory_message):
         points = trajectory_message.points
 
         # Get starting position
-        pos = [list(arm_state.actual.positions)]
+        pos = [list(arm_pos)]
         t = [0]
         for p in points:
             t.append(p.time_from_start.to_sec())
@@ -95,11 +99,11 @@ class SelfCollisionCheck:
 
         return (check_result, violations)
 
-    def check_trajectory_accelerations(self, arm_state, acceleration_limits, trajectory_message):
+    def check_trajectory_accelerations(self, arm_pos, acceleration_limits, trajectory_message):
         points = trajectory_message.points
 
         # Get starting position
-        pos = [list(arm_state.actual.positions)]
+        pos = [list(arm_pos)]
         t = [0]
         for p in points:
             t.append(p.time_from_start.to_sec())
@@ -122,14 +126,14 @@ class SelfCollisionCheck:
 
         return (check_result, violations)
 
-    def check_trajectory_collisions(self, scene, arm_state, joint_names, trajectory_message):
+    def check_trajectory_collisions(self, scene, arm_pos, joint_names, trajectory_message):
 
         # Update model with current joint positions
-        joint_dict = {name : arm_state.actual.positions[i] for i, name in enumerate(joint_names)}
+        joint_dict = {name : arm_pos[i] for i, name in enumerate(joint_names)}
         scene.set_model_state_map(joint_dict)
 
         # Strip JointTrajectory down to be in EXOTica solution form
-        list_traj = [list(arm_state.actual.positions)]
+        list_traj = [arm_pos]
         for i in range(0, len(trajectory_message.points)):
             list_traj.append(list(trajectory_message.points[i].positions))
         exotica_traj = np.array([np.array(x) for x in list_traj])
@@ -143,33 +147,33 @@ class SelfCollisionCheck:
 
                     # if checking collisions, velocities and accelerations
                     if self.check == "cva":
-                        traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
-                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
-                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
+                        traj_check = self.check_trajectory_collisions(self.scene, self.arm_pos, self.names, self.trajectory_message)
+                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_pos, self.velocity_limits, self.trajectory_message)
+                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_pos, self.acceleration_limits, self.trajectory_message)
 
                     # if checking only collisions
                     elif self.check == "c":
-                        traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
+                        traj_check = self.check_trajectory_collisions(self.scene, self.arm_pos, self.names, self.trajectory_message)
                         vel_check, vel_vals = (True, [])
                         accel_check, accel_vals = (True, [])
 
                     # if checking only velocities
                     elif self.check == "v":
                         traj_check = True
-                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
+                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_pos, self.velocity_limits, self.trajectory_message)
                         accel_check, accel_vals = (True, [])
 
                     # if checking only accelerations
                     elif self.check == "a":
                         traj_check = True
                         vel_check, vel_vals = (True, [])
-                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
+                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_pos, self.acceleration_limits, self.trajectory_message)
 
                     # else if checking velocities and accelerations
                     else:
                         traj_check = True
-                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
-                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
+                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_pos, self.velocity_limits, self.trajectory_message)
+                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_pos, self.acceleration_limits, self.trajectory_message)
 
                     # Validates checks in following order: self-collision, velocity limits, acceleration limits - prints first failure
                     if traj_check and vel_check and accel_check:
@@ -178,48 +182,43 @@ class SelfCollisionCheck:
 
                     # If warn, pass trajectory, if error withold trajectory
                     elif not traj_check:
+                        message = "Self-collision detected on following links:\n" + str("\n".join(["%s - %s: %s" % collision for collision in get_colliding_links(self.scene)]))
+
                         if self.mode == 'warn':
-                            print(colours.WARNING + "[WARN] Self-collision detected on following links:")
-                            get_colliding_links(self.scene)
-                            print(colours.ENDC)
+                            rospy.logwarn(message)
                             self.output_traj.publish(self.trajectory_message)
                         elif self.mode == 'error':
-                            print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
-                            get_colliding_links(self.scene)
-                            print(colours.ENDC)
+                            rospy.logerr(message)
 
                     elif not vel_check:
+                        violations = []
+                        for pose in vel_vals:
+                            violations.append(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                        message = "Velocity limits exceeded at following times and links:\n" + str("\n".join(violations))
+
                         if self.mode == 'warn':
-                            print(colours.WARNING + "[WARN] Velocity limits exceeded at following times and links:")
-                            for pose in vel_vals:
-                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
-                            print(colours.ENDC)
+                            rospy.logwarn(message)
                             self.output_traj.publish(self.trajectory_message)
                         elif self.mode == 'error':
-                            print(colours.FAIL + "[ERROR] Velocity limits exceeded at following times and links:")
-                            for pose in vel_vals:
-                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
-                            print(colours.ENDC)
+                            rospy.logerr(message)
 
                     elif not accel_check:
+                        violations = []
+                        for pose in accel_vals:
+                            violations.append(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                        message = "Acceleration limits exceeded at following times and links:\n" + str("\n".join(violations))
+
                         if self.mode == 'warn':
-                            print(colours.WARNING + "[WARN] Acceleration limits exceeded at following times and links:")
-                            for pose in accel_vals:
-                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
-                            print(colours.ENDC)
+                            rospy.logwarn(message)
                             self.output_traj.publish(self.trajectory_message)
                         elif self.mode == 'error':
-                            print(colours.FAIL + "[ERROR] Acceleration limits exceeded at following times and links:")
-                            for pose in accel_vals:
-                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                            rospy.logerr(message)
                             print(colours.ENDC)
                     
                     self.check_trajectory = False
 
-            except Exception as e:
-                print(colours.FAIL + "[ERROR] Self-collision check failed due to:")
-                print(e)
-                print(colours.ENDC)
+            except IndexError:
+                rospy.logerr("Incorrect trajectory size!")
                 self.check_trajectory = False
 
             self.rate.sleep()

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -54,38 +54,43 @@ class SelfCollisionCheck:
 
     def spin(self):
         while not rospy.is_shutdown():
-            if self.check_trajectory:
-                # TODO: Wrap in try/except block
-                # TODO: Currently outputs a self-collision if it starts in self-collision and then moves out of it, is this desired behaviour?
+            try:
+                if self.check_trajectory:
+                    # TODO: Currently outputs a self-collision if it starts in self-collision and then moves out of it, is this desired behaviour?
 
-                # Find robot's current state
-                current_arms = list(self.arm_state.actual.positions)
-                print(current_arms)
+                    # Find robot's current state
+                    current_arms = list(self.arm_state.actual.positions)
 
-                # Strip JointTrajectory down to be in EXOTica solution form
-                list_traj = [current_arms]
-                for i in range(0, len(self.trajectory_message.points)):
-                    list_traj.append(list(self.trajectory_message.points[i].positions))
-                exotica_traj = np.array([np.array(x) for x in list_traj])
+                    # Strip JointTrajectory down to be in EXOTica solution form
+                    list_traj = [current_arms]
+                    for i in range(0, len(self.trajectory_message.points)):
+                        list_traj.append(list(self.trajectory_message.points[i].positions))
+                    exotica_traj = np.array([np.array(x) for x in list_traj])
 
-                traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj)
+                    traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj)
 
-                if traj_check:
-                    # Pass through trajectory
-                    self.output_traj.publish(self.trajectory_message)
-                else:
-                    if self.mode == '-warn':
-                        # Print warning, but also pass through trajectory
-                        print(colours.WARNING + "[WARN] Self-collision detected on following links:")
-                        get_colliding_links(self.problem.get_scene())
-                        print(colours.ENDC)
+                    if traj_check:
+                        # Pass through trajectory
                         self.output_traj.publish(self.trajectory_message)
-                    elif self.mode == '-error':
-                        # Print error, don't pass through trajectory
-                        print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
-                        get_colliding_links(self.problem.get_scene())
-                        print(colours.ENDC)                        
-                
+                    else:
+                        if self.mode == '-warn':
+                            # Print warning, but also pass through trajectory
+                            print(colours.WARNING + "[WARN] Self-collision detected on following links:")
+                            get_colliding_links(self.problem.get_scene())
+                            print(colours.ENDC)
+                            self.output_traj.publish(self.trajectory_message)
+                        elif self.mode == '-error':
+                            # Print error, don't pass through trajectory
+                            print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
+                            get_colliding_links(self.problem.get_scene())
+                            print(colours.ENDC)                        
+                    
+                    self.check_trajectory = False
+
+            except Exception as e:
+                print(colours.FAIL + "[ERROR] Self-collision check failed due to:")
+                print(e)
+                print(colours.ENDC)
                 self.check_trajectory = False
 
             self.rate.sleep()

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -53,44 +53,48 @@ class SelfCollisionCheck:
     
     def check_velocities_accelerations(self, trajectory_message):
         points = trajectory_message.points
-        pos = []
-        dt = []
+
+        # Get starting position
+        pos = [list(self.arm_state.actual.positions)]
+        dt = [0]
+
         for p in points:
             dt.append(p.time_from_start.to_sec())
             pos.append(p.positions)
-        pos = np.array([np.array(x) for x in pos])
-        dt = np.array(dt)
-        velo = np.gradient(pos, dt, axis=0)
-        
-        accel = np.gradient(velo, dt, axis=0)
 
-        #print(self.scene.get_kinematic_tree().get_joint_limits())
+        # Calculate velocities and accelerations, add 0 row to start for t=0
+        velocities = np.true_divide(np.diff(pos, axis=0), np.diff(dt)[:,None])
+        velocities = np.vstack((np.zeros(np.size(velocities, 1)), velocities))
+        accelerations = np.true_divide(np.diff(velocities, axis=0), np.diff(dt)[:,None])
+        accelerations = np.vstack((np.zeros(np.size(accelerations, 1)), accelerations))
+
         velocity_limit = 1.0
 
-        print(velo)
-        result = velo < velocity_limit
+        result = (velocities < velocity_limit) & (velocities > -velocity_limit)
         print(result)
 
+    def check_trajectory_collisions(self, scene, arm_state, joint_names, trajectory_message):
+        # Find robot's current state
+        current_arms = list(arm_state.actual.positions)
+
+        # Update model with current joint positions
+        joint_dict = {name : current_arms[i] for i, name in enumerate(joint_names)}
+        scene.set_model_state_map(joint_dict)
+
+        # Strip JointTrajectory down to be in EXOTica solution form
+        list_traj = [current_arms]
+        for i in range(0, len(trajectory_message.points)):
+            list_traj.append(list(trajectory_message.points[i].positions))
+        exotica_traj = np.array([np.array(x) for x in list_traj])
+
+        return check_whether_trajectory_is_collision_free_by_subsampling(scene, exotica_traj)
 
     def spin(self):
         while not rospy.is_shutdown():
 #            try:
             if self.check_trajectory:
 
-                # Find robot's current state
-                current_arms = list(self.arm_state.actual.positions)
-
-                # Update model with current joint positions
-                joint_dict = {name : current_arms[i] for i, name in enumerate(self.names)}
-                self.scene.set_model_state_map(joint_dict)
-
-                # Strip JointTrajectory down to be in EXOTica solution form
-                list_traj = [current_arms]
-                for i in range(0, len(self.trajectory_message.points)):
-                    list_traj.append(list(self.trajectory_message.points[i].positions))
-                exotica_traj = np.array([np.array(x) for x in list_traj])
-
-                traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.scene, exotica_traj)
+                traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
 
                 self.check_velocities_accelerations(self.trajectory_message)
 

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -50,50 +50,73 @@ class SelfCollisionCheck:
     def arm_callback(self, data):
         # Get current joint states
         self.arm_state = data
+    
+    def check_velocities_accelerations(self, trajectory_message):
+        points = trajectory_message.points
+        pos = []
+        dt = []
+        for p in points:
+            dt.append(p.time_from_start.to_sec())
+            pos.append(p.positions)
+        pos = np.array([np.array(x) for x in pos])
+        dt = np.array(dt)
+        velo = np.gradient(pos, dt, axis=0)
+        
+        accel = np.gradient(velo, dt, axis=0)
+
+        #print(self.scene.get_kinematic_tree().get_joint_limits())
+        velocity_limit = 1.0
+
+        print(velo)
+        result = velo < velocity_limit
+        print(result)
+
 
     def spin(self):
         while not rospy.is_shutdown():
-            try:
-                if self.check_trajectory:
+#            try:
+            if self.check_trajectory:
 
-                    # Find robot's current state
-                    current_arms = list(self.arm_state.actual.positions)
+                # Find robot's current state
+                current_arms = list(self.arm_state.actual.positions)
 
-                    # Update model with current joint positions
-                    joint_dict = {name : current_arms[i] for i, name in enumerate(self.names)}
-                    self.scene.set_model_state_map(joint_dict)
+                # Update model with current joint positions
+                joint_dict = {name : current_arms[i] for i, name in enumerate(self.names)}
+                self.scene.set_model_state_map(joint_dict)
 
-                    # Strip JointTrajectory down to be in EXOTica solution form
-                    list_traj = [current_arms]
-                    for i in range(0, len(self.trajectory_message.points)):
-                        list_traj.append(list(self.trajectory_message.points[i].positions))
-                    exotica_traj = np.array([np.array(x) for x in list_traj])
+                # Strip JointTrajectory down to be in EXOTica solution form
+                list_traj = [current_arms]
+                for i in range(0, len(self.trajectory_message.points)):
+                    list_traj.append(list(self.trajectory_message.points[i].positions))
+                exotica_traj = np.array([np.array(x) for x in list_traj])
 
-                    traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.scene, exotica_traj)
+                traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.scene, exotica_traj)
 
-                    if traj_check:
-                        # Pass through trajectory
+                self.check_velocities_accelerations(self.trajectory_message)
+
+                if traj_check:
+                    # Pass through trajectory
+                    self.output_traj.publish(self.trajectory_message)
+                else:
+                    if self.mode == 'warn':
+                        # Print warning, but also pass through trajectory
+                        print(colours.WARNING + "[WARN] Self-collision detected on following links:")
+                        get_colliding_links(self.scene)
+                        print(colours.ENDC)
                         self.output_traj.publish(self.trajectory_message)
-                    else:
-                        if self.mode == 'warn':
-                            # Print warning, but also pass through trajectory
-                            print(colours.WARNING + "[WARN] Self-collision detected on following links:")
-                            get_colliding_links(self.scene)
-                            print(colours.ENDC)
-                            self.output_traj.publish(self.trajectory_message)
-                        elif self.mode == 'error':
-                            # Print error, don't pass through trajectory
-                            print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
-                            get_colliding_links(self.scene)
-                            print(colours.ENDC)
-                    
-                    self.check_trajectory = False
-
-            except Exception as e:
-                print(colours.FAIL + "[ERROR] Self-collision check failed due to:")
-                print(e)
-                print(colours.ENDC)
+                    elif self.mode == 'error':
+                        # Print error, don't pass through trajectory
+                        print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
+                        get_colliding_links(self.scene)
+                        print(colours.ENDC)
+                
                 self.check_trajectory = False
+
+#            except Exception as e:
+#                print(colours.FAIL + "[ERROR] Self-collision check failed due to:")
+#                print(e)
+#                print(colours.ENDC)
+#                self.check_trajectory = False
 
             self.rate.sleep()
 

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -45,7 +45,7 @@ class SelfCollisionCheck:
         rospack = RosPack()
         urdf = parse(rospack.get_path("nextagea_description") + "/urdf/NextageAOpen.urdf")
         joints = urdf.getElementsByTagName("joint")[-15:] # Nextage has 15 joints: 1 CHEST, 2 HEAD, 6 LARM, 6 RARM
-        all_acceleration_limits = np.array([joint.getElementsByTagName("limit")[0].getAttribute("acceleration") for joint in joints])
+        all_acceleration_limits = [float(joint.getElementsByTagName("limit")[0].getAttribute("acceleration")) for joint in joints]
 
         # Set names for joint group and select acceleration limits to match
         if rospy.resolve_name("~traj_input") == "/collision_botharms_controller/command":
@@ -142,7 +142,7 @@ class SelfCollisionCheck:
 
     def spin(self):
         while not rospy.is_shutdown():
-#            try:
+            try:
             if self.check_trajectory:
 
                 traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
@@ -194,11 +194,11 @@ class SelfCollisionCheck:
                 
                 self.check_trajectory = False
 
-#            except Exception as e:
-#                print(colours.FAIL + "[ERROR] Self-collision check failed due to:")
-#                print(e)
-#                print(colours.ENDC)
-#                self.check_trajectory = False
+            except Exception as e:
+                print(colours.FAIL + "[ERROR] Self-collision check failed due to:")
+                print(e)
+                print(colours.ENDC)
+                self.check_trajectory = False
 
             self.rate.sleep()
 

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -26,6 +26,9 @@ class SelfCollisionCheck:
         # Initial setup and sub/pub to nodes
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
+
+        # TODO: Perhaps this would be better setup as a ROS service that keeps a track of the current robot state
+        # at a set rate (say 2x a second), rather than querying in this program. Minor change
         self.left_arm = rospy.Subscriber(rospy.resolve_name("~larm_input"), JointTrajectoryControllerState, self.larm_callback, queue_size=1)
         self.right_arm = rospy.Subscriber(rospy.resolve_name("~rarm_input"), JointTrajectoryControllerState, self.rarm_callback, queue_size=1)
 
@@ -50,6 +53,7 @@ class SelfCollisionCheck:
         while not rospy.is_shutdown():
             if self.check_trajectory:
                 # TODO: Wrap in try/except block
+                # TODO: Currently outputs a self-collision if it starts in self-collision and then moves out of it
 
                 # Find robot's current state
                 # current_arms = list(self.larm_state.actual.positions) += list(self.rarm_state.actual.positions)

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -24,7 +24,7 @@ class SelfCollisionCheck:
         # Initial setup and sub/pub to nodes
         self.controller_type = CONTROLLER_TYPE
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
-        self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
+        self.output_traj = rospy.Publisher(rospy.resolve_name("~output_input"), JointTrajectory, queue_size=1)
         self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
 
         # Setup EXOTica scene with corresponding JointGroup
@@ -95,28 +95,20 @@ class SelfCollisionCheck:
 
 
 def main(args):
-    import argparse
 
     valid_mode = ["warn", "error"]
     valid_type = ["botharms", "rarm", "larm"]
 
-    parser = argparse.ArgumentParser(description="Nextage self-collision checker")
-    parser.add_argument("--mode", "-m", type=str, nargs="?", default="warn")
-    parser.add_argument("--type", "-t", type=str, nargs="?", default="botharms")
-    parser.add_argument("--remaps", type=str, nargs="?")
-    parser.add_argument('args', nargs=argparse.REMAINDER) # Needed to allow remap args
-    results = parser.parse_args()
-    if results.mode not in valid_mode:
+    MODE = rospy.get_param("/self_collision_check/collision_mode")
+    CONTROLLER_TYPE = rospy.get_param("self_collision_check/controller_type")
+    if MODE not in valid_mode:
+        print("Detected self_collision_check mode: " + MODE)
         print("Invalid collision mode! Use only the following: " + str(valid_mode))
-        parser.print_usage()
         exit(1)
-    if results.type not in valid_type:
+    if CONTROLLER_TYPE not in valid_type:
+        print("Detected self_collision_check controller type: " + CONTROLLER_TYPE)
         print("Invalid controller type! Use only the following: " + str(valid_type))
-        parser.print_usage()
-        exit(1)
-
-    MODE = results.mode
-    CONTROLLER_TYPE = results.type
+        exit(1)  
 
     rospy.init_node('self_collision_check')
     col = SelfCollisionCheck(MODE, CONTROLLER_TYPE)

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -17,8 +17,9 @@ class colours:
     ENDC = '\033[0m'
 
 class SelfCollisionCheck:
-    '''Self-collision checker for the Nextage platform. Node sits in front of trajectory controllers and filters
-    out potentially harmful trajectories that may cause self-collisions'''
+    '''Trajectory checker for the Nextage platform - checks self-collision, velocity and acceleration limits. 
+    Node sits in front of trajectory controllers and filters out potentially harmful trajectories that may cause 
+    self-collisions'''
 
     def __init__(self, MODE, CONTROLLER_TYPE):
         # Initial setup and sub/pub to nodes
@@ -26,7 +27,15 @@ class SelfCollisionCheck:
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
         self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
-        self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5', 'RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
+        if rospy.resolve_name("~traj_input") == "/collision_botharms_controller/command":
+            self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5', 'RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
+        elif rospy.resolve_name("~traj_input") == "/collision_rarm_controller/command":
+            self.names = ['RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
+        elif rospy.resolve_name("~traj_input") == "/collision_larm_controller/command":
+            self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']
+        else:
+            print("UNRECOGNISED TRAJECTORY INPUT: Valid trajectory input topics are: /collision_botharms_controller/command, /collision_rarm_controller/command and /collision_larm_controller/command")
+            exit(1)
 
         # Setup EXOTica scene with corresponding JointGroup
         init = exo.Initializers.SceneInitializer()
@@ -37,6 +46,9 @@ class SelfCollisionCheck:
         init[1]['CollisionScene'] = 'CollisionSceneFCLLatest'
         self.scene = exo.Setup.create_scene(init)
         
+        # Get velocity and acceleration joint limits
+        self.velocity_limits = self.scene.get_kinematic_tree().get_velocity_limits()
+
         self.mode = MODE
         self.check_trajectory = False
         self.rate = rospy.Rate(10)
@@ -51,9 +63,7 @@ class SelfCollisionCheck:
         # Get current joint states
         self.arm_state = data
     
-    def check_trajectory_velocities(self, arm_state, trajectory_message):
-        velocity_limit = 1.0
-        
+    def check_trajectory_velocities(self, arm_state, velocity_limits, trajectory_message):
         points = trajectory_message.points
 
         # Get starting position
@@ -66,7 +76,7 @@ class SelfCollisionCheck:
         # Calculate velocities, add 0 row to start for t=0
         velocities = np.true_divide(np.diff(pos, axis=0), np.diff(t)[:,None])
         velocities = np.vstack((np.zeros(np.size(velocities, 1)), velocities))
-        velocity_check = (velocities < velocity_limit) & (velocities > -velocity_limit)
+        velocity_check = (velocities < velocity_limits) & (velocities > -velocity_limits)
         check_result = velocity_check.all()
 
         # Identify failures & their timestamps
@@ -79,8 +89,6 @@ class SelfCollisionCheck:
         return (check_result, violations)
 
     def check_trajectory_accelerations(self, arm_state, trajectory_message):
-        acceleration_limit = 0.5
-        
         points = trajectory_message.points
 
         # Get starting position
@@ -129,9 +137,10 @@ class SelfCollisionCheck:
             if self.check_trajectory:
 
                 traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
-                vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.trajectory_message)
+                vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits self.trajectory_message)
                 accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.trajectory_message)
 
+                # Checks in following order: self-collision, velocity limits, acceleration limits
                 if traj_check and vel_check and accel_check:
                     # Pass through trajectory
                     self.output_traj.publish(self.trajectory_message)

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -26,6 +26,7 @@ class SelfCollisionCheck:
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
         self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
+        self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5', 'RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
 
         # Setup EXOTica scene with corresponding JointGroup
         init = exo.Initializers.SceneInitializer()
@@ -58,6 +59,10 @@ class SelfCollisionCheck:
 
                     # Find robot's current state
                     current_arms = list(self.arm_state.actual.positions)
+
+                    # Update model with current joint positions
+                    joint_dict = {name : current_arms[i] for i, name in enumerate(self.names)}
+                    self.scene.set_model_state_map(joint_dict)
 
                     # Strip JointTrajectory down to be in EXOTica solution form
                     list_traj = [current_arms]

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -24,7 +24,7 @@ class SelfCollisionCheck:
         # Initial setup and sub/pub to nodes
         self.controller_type = CONTROLLER_TYPE
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
-        self.output_traj = rospy.Publisher(rospy.resolve_name("~output_input"), JointTrajectory, queue_size=1)
+        self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
         self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
 
         # Setup EXOTica scene with corresponding JointGroup
@@ -65,23 +65,23 @@ class SelfCollisionCheck:
                         list_traj.append(list(self.trajectory_message.points[i].positions))
                     exotica_traj = np.array([np.array(x) for x in list_traj])
 
-                    traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj)
+                    traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.scene, exotica_traj)
 
                     if traj_check:
                         # Pass through trajectory
                         self.output_traj.publish(self.trajectory_message)
                     else:
-                        if self.mode == '-warn':
+                        if self.mode == 'warn':
                             # Print warning, but also pass through trajectory
                             print(colours.WARNING + "[WARN] Self-collision detected on following links:")
                             get_colliding_links(self.scene)
                             print(colours.ENDC)
                             self.output_traj.publish(self.trajectory_message)
-                        elif self.mode == '-error':
+                        elif self.mode == 'error':
                             # Print error, don't pass through trajectory
                             print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
                             get_colliding_links(self.scene)
-                            print(colours.ENDC)                        
+                            print(colours.ENDC)
                     
                     self.check_trajectory = False
 
@@ -96,6 +96,7 @@ class SelfCollisionCheck:
 
 def main(args):
 
+    # Get controller_type and mode parameters
     valid_mode = ["warn", "error"]
     valid_type = ["botharms", "rarm", "larm"]
 

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -23,9 +23,13 @@ class SelfCollisionCheck:
     Node sits in front of trajectory controllers and filters out potentially harmful trajectories that may cause 
     self-collisions'''
 
-    def __init__(self, MODE, CONTROLLER_TYPE):
-        # Initial setup and sub/pub to nodes
+    def __init__(self, MODE, CONTROLLER_TYPE, CHECK):
+
         self.controller_type = CONTROLLER_TYPE
+        self.mode = MODE
+        self.check = CHECK
+
+        # Initial setup and sub/pub to nodes
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
         self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
@@ -58,7 +62,6 @@ class SelfCollisionCheck:
             self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']
             self.acceleration_limits = np.array(all_acceleration_limits[3:9])
 
-        self.mode = MODE
         self.check_trajectory = False
         self.rate = rospy.Rate(10)
 
@@ -143,56 +146,76 @@ class SelfCollisionCheck:
     def spin(self):
         while not rospy.is_shutdown():
             try:
-            if self.check_trajectory:
+                if self.check_trajectory:
 
-                traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
-                vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
-                accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
+                    # if checking collisions, velocities and accelerations
+                    if self.check == "cva":
+                        traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
+                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
+                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
 
-                # Checks in following order: self-collision, velocity limits, acceleration limits
-                if traj_check and vel_check and accel_check:
-                    # Pass through trajectory
-                    self.output_traj.publish(self.trajectory_message)
+                    # if checking only collisions
+                    elif self.check == "c":
+                        traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
+                        vel_check, vel_vals = (True, [])
+                        accel_check, accel_vals = (True, [])
 
-                # If warn, pass trajectory, if error withold trajectory
-                elif not traj_check:
-                    if self.mode == 'warn':
-                        print(colours.WARNING + "[WARN] Self-collision detected on following links:")
-                        get_colliding_links(self.scene)
-                        print(colours.ENDC)
+                    # if checking only velocities
+                    elif self.check == "v":
+                        traj_check = True
+                        vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
+                        accel_check, accel_vals = (True, [])
+                        
+                    # if checking only accelerations
+                    else:
+                        traj_check = True
+                        vel_check, vel_vals = (True, [])
+                        accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
+
+                    # Validates checks in following order: self-collision, velocity limits, acceleration limits - prints first failure
+                    if traj_check and vel_check and accel_check:
+                        # Pass through trajectory
                         self.output_traj.publish(self.trajectory_message)
-                    elif self.mode == 'error':
-                        print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
-                        get_colliding_links(self.scene)
-                        print(colours.ENDC)
 
-                elif not vel_check:
-                    if self.mode == 'warn':
-                        print(colours.WARNING + "[WARN] Velocity limits exceeded at following times and links:")
-                        for pose in vel_vals:
-                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
-                        print(colours.ENDC)
-                        self.output_traj.publish(self.trajectory_message)
-                    elif self.mode == 'error':
-                        print(colours.FAIL + "[ERROR] Velocity limits exceeded:")
-                        for pose in vel_vals:
-                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
-                        print(colours.ENDC)
+                    # If warn, pass trajectory, if error withold trajectory
+                    elif not traj_check:
+                        if self.mode == 'warn':
+                            print(colours.WARNING + "[WARN] Self-collision detected on following links:")
+                            get_colliding_links(self.scene)
+                            print(colours.ENDC)
+                            self.output_traj.publish(self.trajectory_message)
+                        elif self.mode == 'error':
+                            print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
+                            get_colliding_links(self.scene)
+                            print(colours.ENDC)
 
-                elif not accel_check:
-                    if self.mode == 'warn':
-                        print(colours.WARNING + "[WARN] Acceleration limits exceeded at following times and links:")
-                        for pose in accel_vals:
-                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
-                        print(colours.ENDC)
-                        self.output_traj.publish(self.trajectory_message)
-                    elif self.mode == 'error':
-                        print(colours.FAIL + "[ERROR] Acceleration limits exceeded:")
-                        for pose in accel_vals:
-                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
-                        print(colours.ENDC)
-                
-                self.check_trajectory = False
+                    elif not vel_check:
+                        if self.mode == 'warn':
+                            print(colours.WARNING + "[WARN] Velocity limits exceeded at following times and links:")
+                            for pose in vel_vals:
+                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                            print(colours.ENDC)
+                            self.output_traj.publish(self.trajectory_message)
+                        elif self.mode == 'error':
+                            print(colours.FAIL + "[ERROR] Velocity limits exceeded:")
+                            for pose in vel_vals:
+                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                            print(colours.ENDC)
+
+                    elif not accel_check:
+                        if self.mode == 'warn':
+                            print(colours.WARNING + "[WARN] Acceleration limits exceeded at following times and links:")
+                            for pose in accel_vals:
+                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                            print(colours.ENDC)
+                            self.output_traj.publish(self.trajectory_message)
+                        elif self.mode == 'error':
+                            print(colours.FAIL + "[ERROR] Acceleration limits exceeded:")
+                            for pose in accel_vals:
+                                print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                            print(colours.ENDC)
+                    
+                    self.check_trajectory = False
 
             except Exception as e:
                 print(colours.FAIL + "[ERROR] Self-collision check failed due to:")
@@ -205,12 +228,14 @@ class SelfCollisionCheck:
 
 def main(args):
 
-    # Get controller_type and mode parameters
+    # Get controller_type, mode and check parameters
     valid_mode = ["warn", "error"]
     valid_type = ["botharms", "rarm", "larm"]
+    valid_check = ["cva", "v", "a"]
 
     MODE = rospy.get_param("/self_collision_check/collision_mode")
     CONTROLLER_TYPE = rospy.get_param("/self_collision_check/controller_type")
+    CHECK = rospy.get_param("/self_collision_check/check_param")
     if MODE not in valid_mode:
         print("Detected self_collision_check mode: " + MODE)
         print("Invalid collision mode! Use only the following: " + str(valid_mode))
@@ -218,10 +243,14 @@ def main(args):
     if CONTROLLER_TYPE not in valid_type:
         print("Detected self_collision_check controller type: " + CONTROLLER_TYPE)
         print("Invalid controller type! Use only the following: " + str(valid_type))
+        exit(1)
+    if CHECK not in valid_check:
+        print("Detected self_collision_check check parameter: " + CHECK)
+        print("Invalid checking options! Use only the following: " + str(valid_check))
         exit(1)  
 
     rospy.init_node('self_collision_check')
-    col = SelfCollisionCheck(MODE, CONTROLLER_TYPE)
+    col = SelfCollisionCheck(MODE, CONTROLLER_TYPE, CHECK)
     try:
         col.spin()
     except KeyboardInterrupt:

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Self-collision checker for Nextage platform
+# Self-collision, velocity & acceleration limit checker for Nextage platform
 
 import pyexotica as exo
 from pyexotica.publish_trajectory import *
@@ -51,27 +51,61 @@ class SelfCollisionCheck:
         # Get current joint states
         self.arm_state = data
     
-    def check_velocities_accelerations(self, trajectory_message):
+    def check_trajectory_velocities(self, arm_state, trajectory_message):
+        velocity_limit = 1.0
+        
         points = trajectory_message.points
 
         # Get starting position
-        pos = [list(self.arm_state.actual.positions)]
-        dt = [0]
-
+        pos = [list(arm_state.actual.positions)]
+        t = [0]
         for p in points:
-            dt.append(p.time_from_start.to_sec())
+            t.append(p.time_from_start.to_sec())
             pos.append(p.positions)
 
-        # Calculate velocities and accelerations, add 0 row to start for t=0
-        velocities = np.true_divide(np.diff(pos, axis=0), np.diff(dt)[:,None])
+        # Calculate velocities, add 0 row to start for t=0
+        velocities = np.true_divide(np.diff(pos, axis=0), np.diff(t)[:,None])
         velocities = np.vstack((np.zeros(np.size(velocities, 1)), velocities))
-        accelerations = np.true_divide(np.diff(velocities, axis=0), np.diff(dt)[:,None])
+        velocity_check = (velocities < velocity_limit) & (velocities > -velocity_limit)
+        check_result = velocity_check.all()
+
+        # Identify failures & their timestamps
+        index = np.where(velocity_check == False)
+        timestamps = []
+        for pose in index[0]:
+            timestamps.append(t[pose])
+        violations = np.column_stack((np.array(timestamps), index[1]))
+
+        return (check_result, violations)
+
+    def check_trajectory_accelerations(self, arm_state, trajectory_message):
+        acceleration_limit = 0.5
+        
+        points = trajectory_message.points
+
+        # Get starting position
+        pos = [list(arm_state.actual.positions)]
+        t = [0]
+        for p in points:
+            t.append(p.time_from_start.to_sec())
+            pos.append(p.positions)
+
+        # Calculate velocities and then accelerations, add 0 row to start for t=0
+        velocities = np.true_divide(np.diff(pos, axis=0), np.diff(t)[:,None])
+        velocities = np.vstack((np.zeros(np.size(velocities, 1)), velocities))
+        accelerations = np.true_divide(np.diff(velocities, axis=0), np.diff(t)[:,None])
         accelerations = np.vstack((np.zeros(np.size(accelerations, 1)), accelerations))
+        acceleration_check = (accelerations < acceleration_limit) & (accelerations > -acceleration_limit)
+        check_result = acceleration_check.all()
 
-        velocity_limit = 1.0
+        # Identify failures & their timestamps
+        index = np.where(acceleration_check == False)
+        timestamps = []
+        for pose in index[0]:
+            timestamps.append(t[pose])
+        violations = np.column_stack((np.array(timestamps), index[1]))
 
-        result = (velocities < velocity_limit) & (velocities > -velocity_limit)
-        print(result)
+        return (check_result, violations)
 
     def check_trajectory_collisions(self, scene, arm_state, joint_names, trajectory_message):
         # Find robot's current state
@@ -95,23 +129,49 @@ class SelfCollisionCheck:
             if self.check_trajectory:
 
                 traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
+                vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.trajectory_message)
+                accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.trajectory_message)
 
-                self.check_velocities_accelerations(self.trajectory_message)
-
-                if traj_check:
+                if traj_check and vel_check and accel_check:
                     # Pass through trajectory
                     self.output_traj.publish(self.trajectory_message)
-                else:
+
+                # If warn, pass trajectory, if error withold trajectory
+                elif not traj_check:
                     if self.mode == 'warn':
-                        # Print warning, but also pass through trajectory
                         print(colours.WARNING + "[WARN] Self-collision detected on following links:")
                         get_colliding_links(self.scene)
                         print(colours.ENDC)
                         self.output_traj.publish(self.trajectory_message)
                     elif self.mode == 'error':
-                        # Print error, don't pass through trajectory
                         print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
                         get_colliding_links(self.scene)
+                        print(colours.ENDC)
+
+                elif not vel_check:
+                    if self.mode == 'warn':
+                        print(colours.WARNING + "[WARN] Velocity limits exceeded at following times and links:")
+                        for pose in vel_vals:
+                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                        print(colours.ENDC)
+                        self.output_traj.publish(self.trajectory_message)
+                    elif self.mode == 'error':
+                        print(colours.FAIL + "[ERROR] Velocity limits exceeded:")
+                        for pose in vel_vals:
+                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                        print(colours.ENDC)
+
+                elif not accel_check:
+                    if self.mode == 'warn':
+                        print(colours.WARNING + "[WARN] Acceleration limits exceeded at following times and links:")
+                        for pose in accel_vals:
+                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
+                        print(colours.ENDC)
+                        self.output_traj.publish(self.trajectory_message)
+                    elif self.mode == 'error':
+                        print(colours.FAIL + "[ERROR] Acceleration limits exceeded:")
+                        for pose in accel_vals:
+                            print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
                         print(colours.ENDC)
                 
                 self.check_trajectory = False

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -10,15 +10,18 @@ import numpy as np
 from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsampling, get_colliding_links
 from trajectory_msgs.msg import JointTrajectoryPoint, JointTrajectory
 from sensor_msgs.msg import JointState
+from control_msgs.msg import JointTrajectoryControllerState
 
 class SelfCollisionCheck:
+    '''Self-collision checker for the Nextage platform. Node sits in front of trajectory controller and filters
+    out potentially harmful trajectories that may cause self-collisions'''
 
     def __init__(self):
         # Initial setup and sub/pub to nodes
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
-        self.left_arm = rospy.Subscriber(rospy.resolve_name("~larm_input"), JointState, self.larm_callback, queue_size=1)
-        self.right_arm = rospy.Subscriber(rospy.resolve_name("~rarm_input"), JointState, self.rarm_callback, queue_size=1)
+        self.left_arm = rospy.Subscriber(rospy.resolve_name("~larm_input"), JointTrajectoryControllerState, self.larm_callback, queue_size=1)
+        self.right_arm = rospy.Subscriber(rospy.resolve_name("~rarm_input"), JointTrajectoryControllerState, self.rarm_callback, queue_size=1)
 
         # Get EXOTica problem
         self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/collision_setup.xml')
@@ -40,23 +43,25 @@ class SelfCollisionCheck:
     def spin(self):
         while not rospy.is_shutdown():
             if self.check_trajectory:
-                try:
-                    # Find robot's current state
-                    current_arm = self.larm_state.points[0].positions
-                    print(current_arm)
+                # TODO: Wrap in try/except block
 
-                    # Process JointTrajectory to be EXOTica solution form
-                    list_traj = []
-                    for i in range(0, len(self.trajectory_message.points)):
-                        list_traj.append(self.trajectory_message.points[i].positions)
-                    exotica_traj = np.array(list_traj)
-                    print(exotica_traj)
-                    
-                    print(check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj))
-                    print(get_colliding_links(self.problem.get_scene()))
-                    self.check_trajectory = False
-                except:
-                    print("ERROR")
+                # Find robot's current state
+                # current_arms = list(self.larm_state.actual.positions) += list(self.rarm_state.actual.positions)
+                current_arms = list(self.rarm_state.actual.positions)
+
+                # Process JointTrajectory to be EXOTica solution form
+                print("TESTING")
+                list_traj = [current_arms]
+
+                for i in range(0, len(self.trajectory_message.points)):
+                    list_traj.append(list(self.trajectory_message.points[i].positions))
+
+                exotica_traj = np.array([np.array(x) for x in list_traj])
+                print(exotica_traj)
+
+                print(check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj))
+                print(get_colliding_links(self.problem.get_scene()))
+                self.check_trajectory = False
 
             self.rate.sleep()
 
@@ -71,23 +76,3 @@ def main(args):
 
 if __name__ == '__main__':
     main(sys.argv)
-
-# Get EXOTica problem from setup
-#exo.Setup.init_ros()
-#problem = exo.Setup.load_problem('{nextagea_gazebo}/config/collision_setup.xml')
-
-#Plan poses
-#init = np.zeros(12)
-#desired = np.zeros(12)
-#desired[6] = 1.5
-
-#trajectory = np.array([init, desired])
-#print(trajectory)
-#print(check_whether_trajectory_is_collision_free_by_subsampling(problem.get_scene(), trajectory))
-#print(get_colliding_links(problem.get_scene()))
-
-
-#for i in range(0, len(goal_pose)):
-#    for t in range(0, len(goal_pose[i])):
-#        publish_pose(goal_pose[i][t], solver.get_problem())
-#        sleep(dt)

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -4,6 +4,7 @@ import pyexotica as exo
 from pyexotica.publish_trajectory import *
 import signal
 import sys
+import warnings
 import rospy
 from time import sleep
 import numpy as np
@@ -11,6 +12,11 @@ from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsam
 from trajectory_msgs.msg import JointTrajectoryPoint, JointTrajectory
 from sensor_msgs.msg import JointState
 from control_msgs.msg import JointTrajectoryControllerState
+
+class colours:
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
 
 class SelfCollisionCheck:
     '''Self-collision checker for the Nextage platform. Node sits in front of trajectory controller and filters
@@ -49,18 +55,22 @@ class SelfCollisionCheck:
                 # current_arms = list(self.larm_state.actual.positions) += list(self.rarm_state.actual.positions)
                 current_arms = list(self.rarm_state.actual.positions)
 
-                # Process JointTrajectory to be EXOTica solution form
-                print("TESTING")
+                # Strip JointTrajectory down to be in EXOTica solution form
                 list_traj = [current_arms]
-
                 for i in range(0, len(self.trajectory_message.points)):
                     list_traj.append(list(self.trajectory_message.points[i].positions))
-
                 exotica_traj = np.array([np.array(x) for x in list_traj])
-                print(exotica_traj)
 
-                print(check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj))
-                print(get_colliding_links(self.problem.get_scene()))
+                traj_check = check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj)
+
+                if traj_check:
+                    # Pass through trajectory
+                    self.output_traj.publish(self.trajectory_message)
+                else:
+                    print(colours.WARNING + "[ WARN ] Self-collision detected on following links")
+                    get_colliding_links(self.problem.get_scene())
+                    print(colours.ENDC)
+                
                 self.check_trajectory = False
 
             self.rate.sleep()

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -71,9 +71,15 @@ class SelfCollisionCheck:
                     # Pass through trajectory
                     self.output_traj.publish(self.trajectory_message)
                 else:
-                    print(colours.WARNING + "[ WARN ] Self-collision detected on following links")
-                    get_colliding_links(self.problem.get_scene())
-                    print(colours.ENDC)
+                    if MODE == '-warn':
+                        print(colours.WARNING + "[WARN] Self-collision detected on following links:")
+                        get_colliding_links(self.problem.get_scene())
+                        print(colours.ENDC)
+                        self.output_traj.publish(self.trajectory_message)
+                    elif MODE == '-error':
+                        print(colours.FAIL + "[ERROR] Self-collision detected on following links:")
+                        get_colliding_links(self.problem.get_scene())
+                        print(colours.ENDC)                        
                 
                 self.check_trajectory = False
 
@@ -81,6 +87,8 @@ class SelfCollisionCheck:
 
 
 def main(args):
+    global MODE 
+    MODE = args[1]
     rospy.init_node('self_collision_check')
     col = SelfCollisionCheck()
     try:

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from pyexotica.publish_trajectory import *
+import signal
+import sys
+import rospy
+from time import sleep
+import numpy as np
+from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsampling, get_colliding_links
+from trajectory_msgs.msg import JointTrajectoryPoint, JointTrajectory
+from sensor_msgs.msg import JointState
+
+class SelfCollisionCheck:
+
+    def __init__(self):
+        # Initial setup and sub/pub to nodes
+        self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.callback, queue_size=1)
+        self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
+        self.left_arm = rospy.Subscriber(rospy.resolve_name("~larm_input"), JointState, self.larm_callback, queue_size=1)
+        self.right_arm = rospy.Subscriber(rospy.resolve_name("~rarm_input"), JointState, self.rarm_callback, queue_size=1)
+
+        # Get EXOTica problem
+        self.problem = exo.Setup.load_problem('{nextagea_gazebo}/config/collision_setup.xml')
+
+        self.check_trajectory = False
+        self.rate = rospy.Rate(10)
+
+    def callback(self, data):
+        # Process JointTrajectory to be EXOTica solution form
+        self.check_trajectory = True
+        self.trajectory_message = data
+    
+    def larm_callback(self, data):
+        self.larm_state = data
+
+    def rarm_callback(self, data):
+        self.rarm_state = data
+
+    def spin(self):
+        while not rospy.is_shutdown():
+            if self.check_trajectory:
+                try:
+                    # Find robot's current state
+                    current_arm = self.larm_state.points[0].positions
+                    print(current_arm)
+
+                    # Process JointTrajectory to be EXOTica solution form
+                    list_traj = []
+                    for i in range(0, len(self.trajectory_message.points)):
+                        list_traj.append(self.trajectory_message.points[i].positions)
+                    exotica_traj = np.array(list_traj)
+                    print(exotica_traj)
+                    
+                    print(check_whether_trajectory_is_collision_free_by_subsampling(self.problem.get_scene(), exotica_traj))
+                    print(get_colliding_links(self.problem.get_scene()))
+                    self.check_trajectory = False
+                except:
+                    print("ERROR")
+
+            self.rate.sleep()
+
+
+def main(args):
+    rospy.init_node('self_collision_check')
+    col = SelfCollisionCheck()
+    try:
+        col.spin()
+    except KeyboardInterrupt:
+        print("Shutting down")
+
+if __name__ == '__main__':
+    main(sys.argv)
+
+# Get EXOTica problem from setup
+#exo.Setup.init_ros()
+#problem = exo.Setup.load_problem('{nextagea_gazebo}/config/collision_setup.xml')
+
+#Plan poses
+#init = np.zeros(12)
+#desired = np.zeros(12)
+#desired[6] = 1.5
+
+#trajectory = np.array([init, desired])
+#print(trajectory)
+#print(check_whether_trajectory_is_collision_free_by_subsampling(problem.get_scene(), trajectory))
+#print(get_colliding_links(problem.get_scene()))
+
+
+#for i in range(0, len(goal_pose)):
+#    for t in range(0, len(goal_pose[i])):
+#        publish_pose(goal_pose[i][t], solver.get_problem())
+#        sleep(dt)

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -60,7 +60,7 @@ class SelfCollisionCheck:
             self.acceleration_limits = np.array(all_acceleration_limits[-6:])
         else:
             self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']
-            self.acceleration_limits = np.array(all_acceleration_limits[3:9])
+            self.acceleration_limits = np.array(all_acceleration_limits[3:9]) # Ignores head and chest joints
 
         self.check_trajectory = False
         self.rate = rospy.Rate(10)
@@ -128,15 +128,13 @@ class SelfCollisionCheck:
         return (check_result, violations)
 
     def check_trajectory_collisions(self, scene, arm_state, joint_names, trajectory_message):
-        # Find robot's current state
-        current_arms = list(arm_state.actual.positions)
 
         # Update model with current joint positions
-        joint_dict = {name : current_arms[i] for i, name in enumerate(joint_names)}
+        joint_dict = {name : arm_state.actual.positions[i] for i, name in enumerate(joint_names)}
         scene.set_model_state_map(joint_dict)
 
         # Strip JointTrajectory down to be in EXOTica solution form
-        list_traj = [current_arms]
+        list_traj = [list(arm_state.actual.positions)]
         for i in range(0, len(trajectory_message.points)):
             list_traj.append(list(trajectory_message.points[i].positions))
         exotica_traj = np.array([np.array(x) for x in list_traj])
@@ -165,7 +163,7 @@ class SelfCollisionCheck:
                         traj_check = True
                         vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
                         accel_check, accel_vals = (True, [])
-                        
+
                     # if checking only accelerations
                     else:
                         traj_check = True
@@ -197,7 +195,7 @@ class SelfCollisionCheck:
                             print(colours.ENDC)
                             self.output_traj.publish(self.trajectory_message)
                         elif self.mode == 'error':
-                            print(colours.FAIL + "[ERROR] Velocity limits exceeded:")
+                            print(colours.FAIL + "[ERROR] Velocity limits exceeded at following times and links:")
                             for pose in vel_vals:
                                 print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
                             print(colours.ENDC)
@@ -210,7 +208,7 @@ class SelfCollisionCheck:
                             print(colours.ENDC)
                             self.output_traj.publish(self.trajectory_message)
                         elif self.mode == 'error':
-                            print(colours.FAIL + "[ERROR] Acceleration limits exceeded:")
+                            print(colours.FAIL + "[ERROR] Acceleration limits exceeded at following times and links:")
                             for pose in accel_vals:
                                 print(self.names[int(pose[1])] + " at t = " + str(pose[0]))
                             print(colours.ENDC)
@@ -231,7 +229,7 @@ def main(args):
     # Get controller_type, mode and check parameters
     valid_mode = ["warn", "error"]
     valid_type = ["botharms", "rarm", "larm"]
-    valid_check = ["cva", "v", "a"]
+    valid_check = ["cva", "c", "v", "a"]
 
     MODE = rospy.get_param("/self_collision_check/collision_mode")
     CONTROLLER_TYPE = rospy.get_param("/self_collision_check/controller_type")

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -42,8 +42,10 @@ class SelfCollisionCheck:
         self.rate = rospy.Rate(10)
 
     def input_callback(self, data):
-        self.check_trajectory = True
-        self.trajectory_message = data
+        # If a trajectory is not currently being processed, get data and check
+        if self.check_trajectory == False:
+            self.check_trajectory = True
+            self.trajectory_message = data
     
     def arm_callback(self, data):
         # Get current joint states

--- a/nextagea_gazebo/scripts/self_collision_check
+++ b/nextagea_gazebo/scripts/self_collision_check
@@ -10,6 +10,8 @@ import numpy as np
 from pyexotica.tools import check_whether_trajectory_is_collision_free_by_subsampling, get_colliding_links
 from trajectory_msgs.msg import JointTrajectory
 from control_msgs.msg import JointTrajectoryControllerState
+from xml.dom.minidom import parse
+from rospkg import RosPack
 
 class colours:
     WARNING = '\033[93m'
@@ -27,15 +29,6 @@ class SelfCollisionCheck:
         self.input_traj = rospy.Subscriber(rospy.resolve_name("~traj_input"), JointTrajectory, self.input_callback, queue_size=1)
         self.output_traj = rospy.Publisher(rospy.resolve_name("~traj_output"), JointTrajectory, queue_size=1)
         self.arm_info = rospy.Subscriber(rospy.resolve_name("~arm_input"), JointTrajectoryControllerState, self.arm_callback, queue_size=1)
-        if rospy.resolve_name("~traj_input") == "/collision_botharms_controller/command":
-            self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5', 'RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
-        elif rospy.resolve_name("~traj_input") == "/collision_rarm_controller/command":
-            self.names = ['RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
-        elif rospy.resolve_name("~traj_input") == "/collision_larm_controller/command":
-            self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']
-        else:
-            print("UNRECOGNISED TRAJECTORY INPUT: Valid trajectory input topics are: /collision_botharms_controller/command, /collision_rarm_controller/command and /collision_larm_controller/command")
-            exit(1)
 
         # Setup EXOTica scene with corresponding JointGroup
         init = exo.Initializers.SceneInitializer()
@@ -46,8 +39,24 @@ class SelfCollisionCheck:
         init[1]['CollisionScene'] = 'CollisionSceneFCLLatest'
         self.scene = exo.Setup.create_scene(init)
         
-        # Get velocity and acceleration joint limits
+        # Get velocity limits
         self.velocity_limits = self.scene.get_kinematic_tree().get_velocity_limits()
+        # Get acceleration limits from the URDF - not part of the URDF standard and so must be manually retrieved
+        rospack = RosPack()
+        urdf = parse(rospack.get_path("nextagea_description") + "/urdf/NextageAOpen.urdf")
+        joints = urdf.getElementsByTagName("joint")[-15:] # Nextage has 15 joints: 1 CHEST, 2 HEAD, 6 LARM, 6 RARM
+        all_acceleration_limits = np.array([joint.getElementsByTagName("limit")[0].getAttribute("acceleration") for joint in joints])
+
+        # Set names for joint group and select acceleration limits to match
+        if rospy.resolve_name("~traj_input") == "/collision_botharms_controller/command":
+            self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5', 'RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
+            self.acceleration_limits = np.array(all_acceleration_limits[-12:])
+        elif rospy.resolve_name("~traj_input") == "/collision_rarm_controller/command":
+            self.names = ['RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
+            self.acceleration_limits = np.array(all_acceleration_limits[-6:])
+        else:
+            self.names = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']
+            self.acceleration_limits = np.array(all_acceleration_limits[3:9])
 
         self.mode = MODE
         self.check_trajectory = False
@@ -88,7 +97,7 @@ class SelfCollisionCheck:
 
         return (check_result, violations)
 
-    def check_trajectory_accelerations(self, arm_state, trajectory_message):
+    def check_trajectory_accelerations(self, arm_state, acceleration_limits, trajectory_message):
         points = trajectory_message.points
 
         # Get starting position
@@ -103,7 +112,7 @@ class SelfCollisionCheck:
         velocities = np.vstack((np.zeros(np.size(velocities, 1)), velocities))
         accelerations = np.true_divide(np.diff(velocities, axis=0), np.diff(t)[:,None])
         accelerations = np.vstack((np.zeros(np.size(accelerations, 1)), accelerations))
-        acceleration_check = (accelerations < acceleration_limit) & (accelerations > -acceleration_limit)
+        acceleration_check = (accelerations < acceleration_limits) & (accelerations > -acceleration_limits)
         check_result = acceleration_check.all()
 
         # Identify failures & their timestamps
@@ -137,8 +146,8 @@ class SelfCollisionCheck:
             if self.check_trajectory:
 
                 traj_check = self.check_trajectory_collisions(self.scene, self.arm_state, self.names, self.trajectory_message)
-                vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits self.trajectory_message)
-                accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.trajectory_message)
+                vel_check, vel_vals = self.check_trajectory_velocities(self.arm_state, self.velocity_limits, self.trajectory_message)
+                accel_check, accel_vals = self.check_trajectory_accelerations(self.arm_state, self.acceleration_limits, self.trajectory_message)
 
                 # Checks in following order: self-collision, velocity limits, acceleration limits
                 if traj_check and vel_check and accel_check:

--- a/nextagea_gazebo/scripts/switch_controller_from_botharms_to_rarm_larm
+++ b/nextagea_gazebo/scripts/switch_controller_from_botharms_to_rarm_larm
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# Switch controller service
+# Switches the Nextage from the default botharms controller to rarm/larm controllers
+
+from controller_manager_msgs.srv import SwitchController
+import rospy
+
+service_name = "/controller_manager/switch_controller"
+rospy.wait_for_service(service_name)
+
+try:
+    switch_controller = rospy.ServiceProxy(service_name, SwitchController)
+
+    # Enforce a strict change between controllers
+    ret = switch_controller(['larm_controller', 'rarm_controller'], 
+                            ['botharms_controller'], 2, True, 0)
+
+except rospy.ServiceException as e:
+    print("Controller switch failed: %s" %e)


### PR DESCRIPTION
Further to the work done in the last PR, the work here extends the self-collision checking node to now include velocity and acceleration checking of any trajectories passed onto the Nextage. The changes made here can be summarised:

- URDF: 
    - I have added an ```acceleration="0.5"``` to each joint in the URDF. This is an arbitrary acceleration limit, as no acceleration limits were previously specified and I haven't been able to find one in the Kawada documentation.
        - TODO: I believe that the velocity (and also the acceleration limits) in the URDF are inaccurate. The velocity limits are all set to 1.0 rad/s - meaning that the wave motion that I used in my previous demo is actually invalid (the end effector moves too fast). Unless the robot was clipping my trajectory to some upper limit, from memory I recall it moving considerably faster than 1.0 rad/s.
- self_collision_check: 
    - I have encapsulated the self-collision checking into its own method, and then created 2 new methods for acceleration and velocity checking. Velocities and accelerations are calculated using np.diff, compared to the velocity/acceleration limits and a bool and a numpy array is returned. The bool is used to indicate whether the trajectory is OK, and the numpy array stores the index of each joint that exceeds the limit - as well as the time in the trajectory when this occurs. This permits richer error behaviour, feeding back to the student what joint is exceeding the limit and when in the trajectory:
![Screenshot from 2020-05-15 19-06-03](https://user-images.githubusercontent.com/5570173/82199677-eb481280-98f5-11ea-8107-6ecf1e242140.png)
![Screenshot from 2020-05-18 10-39-09](https://user-images.githubusercontent.com/5570173/82199687-edaa6c80-98f5-11ea-926e-6d91d85f3bec.png)
    - The acceleration limits are manually parsed from the XML document using minidom. The velocity limits are from EXOTica. (I could set the acceleration limits in EXOTica from here, using the setter I created, but I don't think there would be any benefit here and would just make the program longer?)
- nextagea_world.launch:
    - Added a new parameter ```check_param``` which can be used to specify what the user would like to be checked by the node: ```cva, c, v, a``` - collisions, velocities and accelerations or only one of them. I have added support for this in self_collision_check code.

NOTE: The previous PR is still outstanding and should be merged before this one.