### PR TITLE
[nextagea_moveit_config] Topic remap fix and missing run dependency fix

### DIFF
--- a/nextagea_moveit_config/launch/moveit_rviz.launch
+++ b/nextagea_moveit_config/launch/moveit_rviz.launch
@@ -10,6 +10,7 @@
 
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
 	args="$(arg command_args)" output="screen">
+      <remap from="joint_states" to="/nextagea/joint_states" />
   </node>
 
 </launch>

--- a/nextagea_moveit_config/package.xml
+++ b/nextagea_moveit_config/package.xml
@@ -20,7 +20,6 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>xacro</run_depend>
-
   <build_depend>nextagea_description</build_depend>
   <run_depend>nextagea_description</run_depend>
 </package>

--- a/nextagea_moveit_config/package.xml
+++ b/nextagea_moveit_config/package.xml
@@ -15,10 +15,12 @@
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>xacro</run_depend>
+
   <build_depend>nextagea_description</build_depend>
   <run_depend>nextagea_description</run_depend>
 </package>


### PR DESCRIPTION
This PR contains fixes for 2 issues:
1) The MoveIt crashing issue when using the "Use Cartesian Planning" option - this was due to program not being able to read joint states. This is fixed with the appropriate remap arg.
2) Missing run dependency fix - the simple controller manager package was missed (noticed on fresh install)