### PR TITLE
extrinsic calibration

### DIFF
--- a/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense.urdf.xacro
+++ b/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense.urdf.xacro
@@ -138,7 +138,7 @@
 
   <!-- Attach the RealSense D435 -->
   <joint name="d435_mount_joint" type="fixed">
-      <origin xyz="0 0 0.165" rpy="0 0.325 0"/>
+      <origin xyz="0 0 0.1448322" rpy="0 0.24902114520034205 0"/>
       <parent link="HEAD_JOINT1_Link"/>
       <child link="d435_Mount_Link"/>
   </joint>


### PR DESCRIPTION
This PR updated the `/HEAD_JOINT1_Link` to `/d435_Mount_Link` transformation by manually visual alignment of URDF and images / pointclouds:

![rviz_screenshot_2021_01_18-16_05_41](https://user-images.githubusercontent.com/8226248/104940181-49f3ed80-59a9-11eb-805d-851f95dd7497.png)

![rviz_screenshot_2021_01_18-16_09_31](https://user-images.githubusercontent.com/8226248/104940202-50826500-59a9-11eb-8790-d53defbe278b.png)

![rviz_screenshot_2021_01_18-16_17_45](https://user-images.githubusercontent.com/8226248/104940238-59733680-59a9-11eb-9772-15fa1f0439d2.png)

For reference: The reason for the manual calibration is: https://github.com/ros-planning/moveit_calibration/issues/60.