### PR TITLE
fix URDF installation

### DIFF
--- a/nextagea_description/CMakeLists.txt
+++ b/nextagea_description/CMakeLists.txt
@@ -10,11 +10,6 @@ catkin_package()
 file(GLOB xacro_files urdf/*.urdf.xacro)
 xacro_add_files(${xacro_files} TARGET urdf INSTALL)
 
-install(DIRECTORY models urdf www
+install(DIRECTORY urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
-
-install(DIRECTORY models DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-install(DIRECTORY urdf   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-install(DIRECTORY www    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-


### PR DESCRIPTION
Fix URDF installation. The installed folders `models` and `www` do not exist. I guess they are left-overs from copy&paste.