### PR TITLE
do not load 'NextageAOpen.urdf.xacro' by default

### DIFF
--- a/nextagea_moveit_config/launch/move_group.launch
+++ b/nextagea_moveit_config/launch/move_group.launch
@@ -37,7 +37,7 @@
                 " />
   -->
 
-  <arg name="load_robot_description" default="true" />
+  <arg name="load_robot_description" default="false" />
   <!-- load URDF, SRDF and joint_limits configuration -->
   <include file="$(find nextagea_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />


### PR DESCRIPTION
From the commit message:
```
By default, 'move_group.launch' will override a robot description loaded
earlier. As we might have loaded a different description, e.g.
'NextageAOpen_gazebo_intel_realsense.urdf.xacro' before, this will undo all
changes.
```