### PR TITLE
WIP: model with Azure Kinect camera

### DIFF
--- a/nextagea_description/urdf/NextageAOpen_gazebo_kinect.urdf.xacro
+++ b/nextagea_description/urdf/NextageAOpen_gazebo_kinect.urdf.xacro
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<robot name="NextageAOpen"
+       xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:property name="fixed_base" value="True" />
+  <xacro:property name="ft_sensors" value="True" />
+  <xacro:property name="hand_camera" value="True" />
+
+  <xacro:include filename="$(find nextagea_description)/urdf/NextageAOpen_gazebo.urdf.xacro" />
+
+  <!-- Attach the Azure Kinect -->
+  <joint name="kinct_mount_joint" type="fixed">
+      <origin xyz="0.051 0.0 0.198" rpy="0.0 0.292 0.0" />
+      <parent link="HEAD_JOINT1_Link"/>
+      <child link="camera_base"/>
+  </joint>
+  <link name="camera_base"/>
+
+</robot>


### PR DESCRIPTION
Adds a configuration with the Kinect in place of the RealSense:
![Screenshot from 2021-02-11 16-51-43](https://user-images.githubusercontent.com/8226248/107677144-de442e00-6c91-11eb-93f8-e57dd4415bba.png)

~~I added the transformation to the optical colour frame (`rgb_camera_link`) directly, as the original Azure Kinect URDF is not very detailed and doesn't have collision meshes anyway.~~
The transformation is now given to the `camera_base`, which is the root of the camera transformation tree. The transformations to the optical frames are directly published by the Azure Kinect driver.

Alternatively, we could make the main xacro file configurable or directly move the static transform to the launch file.