### PR TITLE
[nextagea] Optical frame name correction in Gazebo simulation

### DIFF
--- a/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense.urdf.xacro
+++ b/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense.urdf.xacro
@@ -122,10 +122,10 @@
         <infrared1CameraInfoTopicName>infrared/camera_info</infrared1CameraInfoTopicName>
         <infrared2TopicName>infrared2/image_raw</infrared2TopicName>
         <infrared2CameraInfoTopicName>infrared2/camera_info</infrared2CameraInfoTopicName>
-        <colorOpticalframeName>camera_color_optical_frame</colorOpticalframeName>
-        <depthOpticalframeName>camera_depth_optical_frame</depthOpticalframeName>
-        <infrared1OpticalframeName>camera_left_ir_optical_frame</infrared1OpticalframeName>
-        <infrared2OpticalframeName>camera_right_ir_optical_frame</infrared2OpticalframeName>
+        <colorOpticalframeName>nextagea_realsense_color_optical_frame</colorOpticalframeName>
+        <depthOpticalframeName>nextagea_realsense_depth_optical_frame</depthOpticalframeName>
+        <infrared1OpticalframeName>nextagea_realsense_left_ir_optical_frame</infrared1OpticalframeName>
+        <infrared2OpticalframeName>nextagea_realsense_right_ir_optical_frame</infrared2OpticalframeName>
         <rangeMinDepth>0.1</rangeMinDepth>
         <rangeMaxDepth>10</rangeMaxDepth>
         <pointCloud>1</pointCloud>

--- a/nextagea_moveit_config/config/NextageAOpen.srdf
+++ b/nextagea_moveit_config/config/NextageAOpen.srdf
@@ -79,6 +79,9 @@
     <disable_collisions link1="HEAD_JOINT1_Link" link2="nextage_base" reason="Never" />
     <disable_collisions link1="HEAD_JOINT1_Link" link2="nextagea_realsense_link" reason="Adjacent" />
 
+    <disable_collisions link1="CAMERA_HEAD_L_Link" link2="HEAD_JOINT1_Link" reason="Adjacent" />
+    <disable_collisions link1="CAMERA_HEAD_R_Link" link2="HEAD_JOINT1_Link" reason="Adjacent" />
+
     <disable_collisions link1="LARM_JOINT0_Link" link2="LARM_JOINT1_Link" reason="Adjacent" />
     <disable_collisions link1="LARM_JOINT0_Link" link2="RARM_JOINT0_Link" reason="Never" />
     <disable_collisions link1="LARM_JOINT0_Link" link2="WAIST" reason="Never" />

--- a/nextagea_moveit_config/config/sensors_3d.yaml
+++ b/nextagea_moveit_config/config/sensors_3d.yaml
@@ -5,6 +5,6 @@ sensors:
     max_update_rate: 1.0
     padding_offset: 0.1
     padding_scale: 1.0
-    point_cloud_topic: /nextagea/realsense/depth/color/points
+    point_cloud_topic: /nextagea/nextagea_realsense/depth/color/points
     point_subsample: 1
     sensor_plugin: occupancy_map_monitor/PointCloudOctomapUpdater


### PR DESCRIPTION
These are separate, but this branch is based off of #31 so please merge that first.

- This PR fixes a frame name issue in the Gazebo plugin for the Realsense. Previously it was using a generic ```camera_``` prefix, but the tf frame tree shows that it should be ```nextagea_realsense_```:
![image](https://user-images.githubusercontent.com/5570173/107792870-8d920b00-6d4d-11eb-8692-d51987f756ab.png)

- Fix is necessary for the correct use of Realsense. Octomapping and AR tag recognition doesn't work without it.