### PR TITLE
Add realsense Gazebo URDF xacro with realsense plugin but using Azure topic names

### DIFF
--- a/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense_with_Azure_topics.urdf.xacro
+++ b/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense_with_Azure_topics.urdf.xacro
@@ -117,8 +117,8 @@
         <infraredUpdateRate>30</infraredUpdateRate>
         <depthTopicName>depth/image_raw</depthTopicName>
         <depthCameraInfoTopicName>depth/camera_info</depthCameraInfoTopicName>
-        <colorTopicName>color/image_raw</colorTopicName>
-        <colorCameraInfoTopicName>color/camera_info</colorCameraInfoTopicName>
+        <colorTopicName>rgb/image_raw</colorTopicName>
+        <colorCameraInfoTopicName>rgb/camera_info</colorCameraInfoTopicName>
         <infrared1TopicName>infrared/image_raw</infrared1TopicName>
         <infrared1CameraInfoTopicName>infrared/camera_info</infrared1CameraInfoTopicName>
         <infrared2TopicName>infrared2/image_raw</infrared2TopicName>

--- a/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense_with_Azure_topics.urdf.xacro
+++ b/nextagea_description/urdf/NextageAOpen_gazebo_intel_realsense_with_Azure_topics.urdf.xacro
@@ -1,0 +1,161 @@
+<?xml version="1.0"?>
+<robot name="NextageAOpen"
+       xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:property name="fixed_base" value="True" />
+  <xacro:property name="ft_sensors" value="True" />
+  <xacro:property name="hand_camera" value="True" />
+
+  <xacro:include filename="$(find nextagea_description)/urdf/NextageAOpen_gazebo.urdf.xacro" />
+  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+
+  <xacro:macro name="sensor_d435_gz" params="name">
+    <gazebo reference="${name}_color_frame">
+      <sensor name="color" type="camera">
+        <pose frame="">0 0 0 0 0 0</pose>
+        <camera name="__default__">
+          <horizontal_fov>1.5009831567151233</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>RGB_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>1</visualize>
+      </sensor>
+    </gazebo>
+    <gazebo reference="${name}_infra1_frame">
+      <sensor name="ired1" type="camera">
+        <pose frame="">0 0 0 0 0 0</pose>
+        <camera name="__default__">
+          <horizontal_fov>1.5009831567151233</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>L_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+      </sensor>
+    </gazebo>
+    <gazebo reference="${name}_infra2_frame">
+      <sensor name="ired2" type="camera">
+        <pose frame="">0 0 0 0 0 0</pose>
+        <camera name="__default__">
+          <horizontal_fov>1.5009831567151233</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>L_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+      </sensor>
+    </gazebo>
+    <gazebo reference="${name}_depth_frame">
+      <sensor name="depth" type="depth">
+        <pose frame="">0 0 0 0 0 0</pose>
+        <camera name="__default__">
+          <horizontal_fov>1.5009831567151233</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+      </sensor>
+    </gazebo>
+    <gazebo>
+    <!-- GAZEBO REALSENSE PLUGIN WITH AZURE TOPIC NAMES -->
+      <plugin name="${name}" filename="librealsense_gazebo_plugin.so">
+        <depthUpdateRate>30</depthUpdateRate>
+        <colorUpdateRate>30</colorUpdateRate>
+        <infraredUpdateRate>30</infraredUpdateRate>
+        <depthTopicName>depth/image_raw</depthTopicName>
+        <depthCameraInfoTopicName>depth/camera_info</depthCameraInfoTopicName>
+        <colorTopicName>color/image_raw</colorTopicName>
+        <colorCameraInfoTopicName>color/camera_info</colorCameraInfoTopicName>
+        <infrared1TopicName>infrared/image_raw</infrared1TopicName>
+        <infrared1CameraInfoTopicName>infrared/camera_info</infrared1CameraInfoTopicName>
+        <infrared2TopicName>infrared2/image_raw</infrared2TopicName>
+        <infrared2CameraInfoTopicName>infrared2/camera_info</infrared2CameraInfoTopicName>
+        <colorOpticalframeName>azure_color_optical_frame</colorOpticalframeName>
+        <depthOpticalframeName>azure_depth_optical_frame</depthOpticalframeName>
+        <infrared1OpticalframeName>azure_left_ir_optical_frame</infrared1OpticalframeName>
+        <infrared2OpticalframeName>azure_right_ir_optical_frame</infrared2OpticalframeName>
+        <rangeMinDepth>0.1</rangeMinDepth>
+        <rangeMaxDepth>10</rangeMaxDepth>
+        <pointCloud>1</pointCloud>
+        <pointCloudTopicName>points2</pointCloudTopicName>
+        <pointCloudCutoff>0.15</pointCloudCutoff>
+        <pointCloudCutoffMax>10</pointCloudCutoffMax>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+
+  <!-- Attach the RealSense D435 -->
+  <joint name="d435_mount_joint" type="fixed">
+      <origin xyz="0 0 0.1448322" rpy="0 0.24902114520034205 0"/>
+      <parent link="HEAD_JOINT1_Link"/>
+      <child link="d435_Mount_Link"/>
+  </joint>
+
+  <link name="d435_Mount_Link">
+    <inertial>
+        <mass value="0.01"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <xacro:sphere_inertia_def radius="0.02" mass="0.01"/>
+    </inertial>
+  </link>
+
+  <xacro:sensor_d435 name="azure" parent="d435_Mount_Link" use_nominal_extrinsics="true">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+  </xacro:sensor_d435>
+
+  <xacro:sensor_d435_gz name="azure" />
+
+</robot>


### PR DESCRIPTION
This adds a new launch file for the Realsense in Gazebo that is identical to the other one, but most importantly uses topic names for the Microsoft Azure Kinect that is mounted on the Nextagea robot. This should allow rapid sim to real integration from Gazebo to the real hardware - without changing topic names and remapping. Mainly this involves having the depth cloud present itself on ```nextagea/azure/points2```.

In the future, we may decide to add the Azure mesh and to the URDF for proper integration of this RGBD camera into the Gazebo simulation, but the mesh is brand new (from yesterday): https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/101 and requires setting up. 