### PR TITLE
By default set use_cables to false.

### DIFF
--- a/nextagea_description/urdf/nextagea.urdf.xacro
+++ b/nextagea_description/urdf/nextagea.urdf.xacro
@@ -19,10 +19,14 @@
   <xacro:include filename="$(find nextagea_description)/urdf/robot/nextagea_robot.xacro" />
   <xacro:include filename="$(find nextagea_description)/urdf/tool/nextagea_tools.xacro" />
 
+  <!-- Arguments for use_cables -->
+  <xacro:arg name="use_cables_left" default="false" />
+  <xacro:arg name="use_cables_right" default="false" />
+
   <!-- Include the nextagea base, robot torso, and tools -->
   <xacro:nextagea_robot/>
   <xacro:nextagea_base/>
-  <xacro:nextagea_tools prefix="L" use_cables="false"/>
-  <xacro:nextagea_tools prefix="R" use_cables="false"/>
+  <xacro:nextagea_tools prefix="L" use_cables="$(arg use_cables_left)"/>
+  <xacro:nextagea_tools prefix="R" use_cables="$(arg use_cables_right)"/>
 
 </robot>

--- a/nextagea_description/urdf/nextagea.urdf.xacro
+++ b/nextagea_description/urdf/nextagea.urdf.xacro
@@ -22,7 +22,7 @@
   <!-- Include the nextagea base, robot torso, and tools -->
   <xacro:nextagea_robot/>
   <xacro:nextagea_base/>
-  <xacro:nextagea_tools prefix="L" use_cables="true"/>
+  <xacro:nextagea_tools prefix="L" use_cables="false"/>
   <xacro:nextagea_tools prefix="R" use_cables="false"/>
 
 </robot>


### PR DESCRIPTION
Minor change. 

By default, it doesn't make sense to `use_cables` for one arm and not the other. I think it makes more sense for them to be set to `false` by default - also renders ugly collision spheres in PyBullet.